### PR TITLE
add description file

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,0 +1,23 @@
+Package: nfiidd
+Title: Material to support course on nowcasting and forecasting of infectious
+    disease dynamics
+Version: 0.0.0.9999
+Authors@R: c(
+    person(
+      given = "Sebastian",
+      family = "Funk",
+      role = c("cre", "cph", "aut"),
+      email = "sebastian.funk@lshtm.ac.uk",
+      comment = c(ORCID = "0000-0002-2842-3406")
+    )
+  )
+Description: Resources to support a short course on nowcasting and forecasting
+    of infectious disease dynamics.
+License: MIT + file LICENSE
+URL: https://github.com/nfidd/nfidd
+BugReports: https://github.com/nfidd/nfiidd/issues
+Depends:
+    R (>= 4.2.0)
+Encoding: UTF-8
+Language: en-GB
+LazyData: true


### PR DESCRIPTION
I'm thinking this might be the easiest way to get course participants to install participants (via `remotes::install_github()`), and to ship data sets.