### PR TITLE
Further modularise learning objectives

### DIFF
--- a/learning_objectives.md
+++ b/learning_objectives.md
@@ -12,17 +12,14 @@
 - understanding of the ubiquity of delays in epidemiological data
 - understanding of how delays affect population-level epidemiological data via discrete convolutions
 - ability to apply convolutions of discrete probability distributions to epidemiological data in R
+
+## Biases in delay distributions
+
 - understanding of how censoring affects the estimation and interpretation of epidemiological delay distributions
 - ability to estimate parameters of probability distributions from observed delays, taking into account censoring, using R
-
-## Right truncation and nowcasting
-
 - understanding of right truncation in epidemiolgical data
 - ability to estimate parameters of probability distributions from observed delays, taking into account truncation, in R
-- understanding of nowcasting as a particular right truncation problem
-- ability to perform a simple nowcast in R
-- awareness of the breadth of methods to perform nowcasting
-
+  
 ## R estimation and the renewal equation
 
 - understanding of the reproduction number and challenges in its estimation
@@ -32,13 +29,23 @@
 - familiarity with the generation time as a particular type of delay distributions
 - ability to estimate static and time-varying reproduction numbers from time-series data in R
 
+## Nowcasting
+
+- understanding of nowcasting as a particular right truncation problem
+- Ability to perform a simple nowcast in R
+- awareness of the breadth of methods to perform nowcasting
+- R estimation as a nowcasting problem
+
 ## Forecasting
 
 - understanding of forecasting as an epidemiological problem, and its relationship with nowcasting and R estimation
 - understanding of the difference between forecasts, projections and scenarios
 - familiarity with common forecasting models and their properties, and applicability in epidemiology
 - ability to use a common forecasting model on an epidemiological time series in R
-- ability to use a mechanistic model for forecasting an epidemiological time series in R
+- ability to use a semi-mechanistic model for forecasting an epidemiological time series in R
+
+## Ensemble models
+
 - understanding of predictive ensembles and their properties
 - ability to create a predictive ensemble of forecasts in R
 


### PR DESCRIPTION
Thinking about the learning objectives as a lesson plan I have further modularised them and made a distinct sections for biases in delay distributions, ensemble modelling, and delay estimation.

The biases in delay distribution section I think particularly makes sense as then it is clear how to pull things from our two recent papers on this.