### PR TITLE
gitignore for sessions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@
 _site
 .DS_Store
 /.quarto/
+sessions/*/*
+!sessions/*/*.qmd
+!sessions/*/*.stan


### PR DESCRIPTION
directories might contain
- compiled stan files
- compiled quarto files
which this will cause to be ignored