### PR TITLE
render on PRs

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -4,6 +4,8 @@ on:
   workflow_dispatch:
   push:
     branches: [main, master]
+  pull_request:
+    branches: [main, master]
 
 name: deploy
 
@@ -38,6 +40,7 @@ jobs:
         run: quarto render
 
       - name: Deploy to GitHub pages 🚀
+        if: github.event_name != 'pull_request'
         uses: JamesIves/github-pages-deploy-action@v4.6.1
         with:
           branch: gh-pages


### PR DESCRIPTION
At the moment pages only get rendered upon push to main which is a bit late - with this PR that happens in PRs (without deployment) which should help catch errors.