### PR TITLE
installing cmdstan step

### DIFF
--- a/getting-set-up.qmd
+++ b/getting-set-up.qmd
@@ -16,3 +16,20 @@ Then you can check that the installation completed successfully by loading the p
 ```{r load, eval=FALSE}
 library("nfiidd")
 ```
+
+# Installing `cmdstan`
+
+The course relies on running stan through the `cmdstanr` **R** package, which itself uses the `cmdstan` software.
+This requires a separate installation step, see [Installing CmdS]
+
+```{r cmdstan_install, eval = FALSE}
+cmdstanr::install_cmdstan()
+```
+
+You can test that you have a working `cmdstanr` setup using
+
+```{r cmdstan_test}```
+cmdstanr::cmdstan_version()
+```
+
+For more details, and for links to resources in case something goes wrong, see the [Getting Started with CmdStanr](https://mc-stan.org/cmdstanr/articles/cmdstanr.html) vignette of the package.

--- a/getting-set-up.qmd
+++ b/getting-set-up.qmd
@@ -33,7 +33,7 @@ cmdstanr::check_cmdstan_toolchain(fix = TRUE)
 
 You can test that you have a working `cmdstanr` setup using
 
-```{r cmdstan_test}```
+```{r cmdstan_test}
 cmdstanr::cmdstan_version()
 ```
 

--- a/getting-set-up.qmd
+++ b/getting-set-up.qmd
@@ -26,6 +26,11 @@ This requires a separate installation step:
 cmdstanr::install_cmdstan()
 ```
 
+If there are any problems with this, you can try (on Windows) to fix them using
+```{r cmdstan_toolchain, eval = FALSE}
+cmdstanr::check_cmdstan_toolchain(fix = TRUE)
+```
+
 You can test that you have a working `cmdstanr` setup using
 
 ```{r cmdstan_test}```

--- a/getting-set-up.qmd
+++ b/getting-set-up.qmd
@@ -20,7 +20,7 @@ library("nfiidd")
 # Installing `cmdstan`
 
 The course relies on running stan through the `cmdstanr` **R** package, which itself uses the `cmdstan` software.
-This requires a separate installation step, see [Installing CmdS]
+This requires a separate installation step:
 
 ```{r cmdstan_install, eval = FALSE}
 cmdstanr::install_cmdstan()


### PR DESCRIPTION
Adds a section on install `cmdstan` to the "Getting Setup" vignette - for people to do in advance of the course.