### PR TITLE
Initial runthrough for clarity

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -1,0 +1,2 @@
+^.*\.Rproj$
+^\.Rproj\.user$

--- a/nfidd.Rproj
+++ b/nfidd.Rproj
@@ -1,0 +1,22 @@
+Version: 1.0
+
+RestoreWorkspace: Default
+SaveWorkspace: Default
+AlwaysSaveHistory: Default
+
+EnableCodeIndexing: Yes
+UseSpacesForTab: Yes
+NumSpacesForTab: 2
+Encoding: UTF-8
+
+RnwWeave: Sweave
+LaTeX: pdfLaTeX
+
+AutoAppendNewline: Yes
+StripTrailingWhitespace: Yes
+
+BuildType: Package
+PackageUseDevtools: Yes
+PackageInstallArgs: --no-multiarch --with-keep.source
+
+MarkdownWrap: Sentence

--- a/sessions/biases-in-delay-distributions.qmd
+++ b/sessions/biases-in-delay-distributions.qmd
@@ -12,8 +12,7 @@ set.seed(123)
 # Objectives
 
 The aim of this session is to introduce some specific issues that arise when we use delay distributions to describe reporting in infectious disease epidemiology.
-Specifically, we will consider two types of biases that commonly occur in infectious disease data: _censoring_ and _truncation_.
-
+Specifically, we will consider two types of biases that commonly occur in infectious disease data: *censoring* and *truncation*.
 
 # Libraries used
 
@@ -31,20 +30,33 @@ library("cmdstanr")
 
 ## Create data set
 
-We will use the same simulated data set as in the [session on delay distributions](delay-distributions#simulating-delayed-epidemiological-data) but introduce some typical properties of infectious disease data sets.
+We will use the same simulated data set as in the [session on delay distributions](delay-distributions#simulating-delayed-epidemiological-data).
+In this session, we'll introduce some typical properties of infectious disease data sets.
 
+::: callout-note
+Remember, in our simulated data:
+
+-   the incubation period is **gamma**-distributed with **shape 5** and **rate 1**, i.e. a mean of 5 days
+
+-   the time from onset to hospital admission is **lognormally**-distributed, with **meanlog 1.75** and **sdlog 0.5**, i.e. a mean delay of about a week
+:::
+
+::: callout-tip
 If you need to re-load the data, here is the code again from that session:
 
 ```{r inf_hosp_solution, file = here::here("snippets", "onset-hosp.r")}
 ```
+:::
 
 ## Dates, not days: censoring
 
 Data on health outcomes are usually not recorded in the way that we have used so far in this session: as a numeric time since a given start date.
-Instead, we usually deal with _dates_.
-To simulate this, we can round down the infection times in the data set above using the `floor()` function:
+Instead, we usually deal with *dates*.
+
+We can make our simulated dataset a bit more realistic by rounding down the infection times to an integer number.
 
 ```{r censored_times}
+# Use the floor() function to round down to integers
 df_dates <- df |>
   mutate(
     infection_time = floor(infection_time),
@@ -54,19 +66,24 @@ df_dates <- df |>
 head(df_dates)
 ```
 
-::: {.callout-note}
-As before we are still not working with dates but numbers, which makes handling the data easier - we don't have to make any conversions before using the data in stan.
-However, now these are integer numbers because we have rounded down the numbers using the `floor()` function.
+::: callout-note
+As before we are still not working with dates but numbers.
+This makes handling the data easier - we don't have to make any conversions before using the data in stan.
+:::
+
 Each of the numbers now represent the number of days that have passed since the start of the outbreak.
 That is, each of the numbers correspond to a day.
 In that sense, the data is more like typical data we get from infectious disease outbreaks.
-:::
+However, we have now *censored* the data.
 
 ## Estimating delay distributions accounting for censoring
 
-A naïve approach to estimating the delay from symptom onset to hospitalisation would be to ignore the fact that we have rounded down the times and just take use difference in days for the estimation.
+Let's estimate the time from symptom onset to hospitalisation with the censored data.
 
-```{r}
+A naïve approach to estimating the delay would be to ignore the fact that the data are censored.
+To estimate the delay from onset to hospitalisation, we could just use the integer difference in days.
+
+```{r integer-delays}
 df_dates <- df_dates |>
   mutate(
     incubation_period = onset_time - infection_time,
@@ -74,14 +91,17 @@ df_dates <- df_dates |>
   )
 ```
 
-::: {.callout-tip}
+::: callout-tip
 ## Take 5 minutes
+
 Fit the lognormal model used in the [session on delay distributions](delay-distributions#estimating-delay-distributions) to the estimates from the rounded data, i.e. using the `df_dates` data set.
+
 Do you still recover the parameters that we put in?
 :::
 
 ::: {.callout-note collapse="true"}
 ## Solution
+
 ```{r df_dates_solution}
 mod <- cmdstan_model(here("stan", "lognormal.stan"))
 res <- mod$sample(
@@ -97,27 +117,30 @@ res
 Usually the estimates will be further from the "true" parameters than before when we worked with the unrounded data.
 :::
 
-If we want to modify the model in order to account for censoring, we need to take into account that we don't know when exactly on any given day the event happened.
+To account for censoring, we need to modify the model to include the fact that we don't know when exactly on any given day the event happened.
 For example, if we know that symptom onset of an individual occurred on 20 June, 2024, and they were admitted to hospital on 22 June, 2024, this could mean an onset-to-hospitalisation delay from 1 day (onset at 23:59 on the 20th, admitted at 0:01 on the 22nd) to 3 days (onset at 0:01 on the 20th, admitted at 23:59 on the 22nd).
+
 We can use this in our delay estimation by making the exact time of the events based on the dates given part of the estimation procedure:
 
 ```{r censoring_adjusted_delay_model}
 cmod <- cmdstan_model(here("stan", "censored_delay_model.stan"))
-mod$print(line_numbers = TRUE)
+cmod$print(line_numbers = TRUE)
 ```
 
-::: {.callout-tip}
+::: callout-tip
 ## Take 5 minutes
-Familarise yourself with the model above.
+
+Familiarise yourself with the model above.
 Do you understand all the lines?
 Which line(s) define the parameter prior distribution(s), which one(s) the likelihood, and which one(s) reflect that we have now provided the delay as the difference in integer days?
 :::
 
 ::: {.callout-note collapse="true"}
 ## Solution
+
 Lines 21-24 define the parametric prior distributions (for parameters meanlog and sdlog, and the estimates of exact times of events).
-Line 26 defines the likelihood.
-Lines 15-17 reflect the integer delays, adjusted by the estimated times of day
+Line 27 defines the likelihood.
+Lines 15-17 reflect the integer delays, adjusted by the estimated times of day.
 :::
 
 Now we can use this model to re-estimate the parameters of the delay distribution:
@@ -133,8 +156,9 @@ cres <- cmod$sample(
 cres
 ```
 
-::: {.callout-tip}
+::: callout-tip
 ## Take 10 minutes
+
 Try re-simulating the delays using different parameters of the delay distribution.
 Can you establish under which conditions the bias in estimation gets worse?
 :::
@@ -142,40 +166,48 @@ Can you establish under which conditions the bias in estimation gets worse?
 ## Real-time estimation: truncation
 
 The data set we have looked at so far in this session is a "final" data set representing an outbreak that has come and gone.
-However, information e.g. on delay distribution is often important during ongoing outbreaks as they can inform nowcasts and forecasts and help with broader interpretation of data.
-Estimating delays in real time comes with particular challenges as the timing of the cut-off might introduce a bias.
-If, for example, infections are exponentially increasing then there will be disproportionately more people with recent symptom onset, decreasing the estimate of the mean delay.
+However, information on delay distribution is often important during ongoing outbreaks as they can inform nowcasts and forecasts and help with broader interpretation of data.
+
+Estimating delays in real time comes with particular challenges, as the timing of the cut-off might introduce a bias.
+If, for example, infections are exponentially increasing then there will be disproportionately more people with recent symptom onset.
+This would artificially decrease the estimate of the mean delay compared to its true value for all infections.
 This happens because most infections are recent (due to the exponential increase), but later symptom onsets amongst these have not had a chance to happen yet.
-Once again, we can simulate this effect, for example by imagining we would like to make an estimate on day 40.
-Let us work with the un-censored data for the time from onset to hospitalisation so as to look at the issue of truncation in isolation:
+
+Once again, we can simulate this effect, for example by imagining we would like to make an estimate on day 40 of our outbreak.
+Let us work with the original, un-censored data for the time from onset to hospitalisation so as to look at the issue of truncation in isolation:
 
 ```{r truncated_df}
-df_rt <- df |>
+df_realtime <- df |>
   mutate(onset_to_hosp = hosp_time - onset_time) |>
   filter(hosp_time <= 40)
 ```
 
-## Estimating delay distributions accounting for censoring
+## Estimating delay distributions accounting for truncation
 
-If we take the naïve mean of delays we get an underestimate as expected
+If we take the naïve mean of delays we get an underestimate as expected:
 
 ```{r mean_truncated}
-  mean(df_rt$onset_to_hosp)
+# truncated mean delay
+mean(df_realtime$onset_to_hosp)
+# compare with the mean delay over the full outbreak
+mean(df$hosp_time - df$onset_time, na.rm=TRUE)
 ```
 
-::: {.callout-tip}
+::: callout-tip
 ## Take 5 minutes
-Fit the lognormal model used above to the estimates from the truncated data, i.e. using the `df_rt` data set.
+
+Fit the lognormal model used above to the estimates from the truncated data, i.e. using the `df_realtime` data set.
 How far away from the "true" parameters do you end up?
 :::
 
 ::: {.callout-note collapse="true"}
 ## Solution
-```{r df_rt_solution}
+
+```{r df_realtime_solution}
 res <- mod$sample(
   data = list(
-    n = nrow(na.omit(df_rt)),
-    y = na.omit(df_rt)$onset_to_hosp
+    n = nrow(na.omit(df_realtime)),
+    y = na.omit(df_realtime)$onset_to_hosp
   ),
   refresh = 0, show_exceptions = FALSE, show_messages = FALSE
 )
@@ -190,15 +222,17 @@ tmod <- cmdstan_model(here("stan", "truncated_delay_model.stan"))
 tmod$print(line_numbers = TRUE)
 ```
 
-::: {.callout-tip}
+::: callout-tip
 ## Take 5 minutes
+
 Familiarise yourself with the model above.
 Which line introduces the truncation, i.e. the fact that we have not been able to observe hospitalisation times beyond the cutoff of (here) 40 days?
 :::
 
 ::: {.callout-note collapse="true"}
 ## Solution
-Line 17 defines the upper limit of `onset_to_hosp` as `time_since_onset`
+
+Line 17 defines the upper limit of `onset_to_hosp` as `time_since_onset`.
 :::
 
 Now we can use this model to re-estimate the parameters of the delay distribution:
@@ -206,24 +240,25 @@ Now we can use this model to re-estimate the parameters of the delay distributio
 ```{r truncated_estimate}
 tres <- tmod$sample(
   data = list(
-    n = nrow(df_rt),
-    onset_to_hosp = df_rt$onset_to_hosp, 
-    time_since_onset = 40 - df_rt$onset_time
+    n = nrow(df_realtime),
+    onset_to_hosp = df_realtime$onset_to_hosp, 
+    time_since_onset = 40 - df_realtime$onset_time
   ),
   refresh = 0, show_exceptions = FALSE, show_messages = FALSE
 )
 tres
 ```
 
-::: {.callout-tip}
+::: callout-tip
 ## Take 10 minutes
+
 Try re-simulating the delays using different parameters of the delay distribution.
 Can you establish under which conditions the bias in estimation gets worse?
 :::
 
 # Going further
 
-- We have looked at censoring and truncation separately, but in reality often both are present. Can you combine the two in a model?
-- The solutions we introduced for addressing censoring and truncation are only some possible ones for the censoring problem. There are other solutions that reduce the biase from estimation even further. For a full overview, the [review by Park et al.](https://doi.org/10.1101/2024.01.12.24301247) might be worth a read. If you are feeling adventurous, try to implement one or more of them in the stan model above - with a warning that this can get quite involved very quickly.
+-   We have looked at censoring and truncation separately, but in reality often both are present. Can you combine the two in a model?
+-   The solutions we introduced for addressing censoring and truncation are only some possible ones for the censoring problem. There are other solutions that reduce the biases from estimation even further. For a full overview, the [review by Park et al.](https://doi.org/10.1101/2024.01.12.24301247) might be worth a read. If you are feeling adventurous, try to implement one or more of them in the stan model above - with a warning that this can get quite involved very quickly.
 
 # Wrap up

--- a/sessions/delay-distributions.qmd
+++ b/sessions/delay-distributions.qmd
@@ -36,11 +36,16 @@ For now we will not concern ourselves with the model used to generate the epidem
 This represents a typical situation in the real world, where we may have a model of how an infection has spread, but we don't know necessary know how well this corresponds to what really happened.
 
 We will later deal with modelling the infectious process.
-For now, we will focus on modelling the *observation* process, in particular the fact that we don't normally observe infections directly but their outcomes as symptomatic cases, hospitalisations or other realisations.
-We will further consider the fact that these observations are *incomplete* (e.g. because not every infection leads to hospitalisations and so focusing on hospitalisations may leave infections unobserved) and happen with a delay (e.g. from infection to symptoms).
+For now, we will focus on modelling how infections get reported in data - the *observation* process.
+This has three issues:
+
+1.  We don't normally observe infections directly, but their *outcomes* as symptomatic cases, hospitalisations or other realisations.
+2.  These observations are *incomplete* (e.g. because not every infection leads to hospitalisation, and so focusing on hospitalisations may leave infections unobserved)
+3.  These observations happen with a *delay* after the infection occurs (e.g. from infection to symptoms).
 
 We will work with a data set that is included in the `nfidd` R package that you installed initially.
-It can be loaded with the `data` command
+The column `infection_time` is a linelist of infections, given as a decimal number of days that have passed since the initial infection of the outbreak.
+It can be loaded with the `data` command.
 
 ```{r}
 data(infection_times)
@@ -53,30 +58,52 @@ ggplot(infection_times, aes(x = infection_time)) +
   ylab("Number of infections")
 ```
 
-::: {.callout-note}
-You can see that the column `infection_time` is given as a decimal number of days that have passed since the initial infection of the outbreak.
-In reality, data from an outbreak will usually be given as dates, and those will usually not represent infection but an observed outcome such as symptom onset or hospital admission.
+::: callout-note
+In reality, data from an outbreak will usually be given as dates, not decimals; and those will usually not represent infection, but an observed outcome such as symptom onset or hospital admission.
 For now we don't want to spend too much time manipulating dates in R, but we will get back to working with more realistic outbreak data later.
 :::
 
 We would now like to simulate hospitalisations arising from this outbreak.
-We assume that the incubation period (or the number of days from infection to symptom onset) is gamma-distributed with shape 5 and rate 1, i.e. a mean of 5 days.
-We further assume that the onset-to-hospitalisation period (or the number of days from symptom onset to hospital admission) is lognormally distributed with meanlog 1.75 and sdlog 0.5, corresponding to a mean delay of about a week.
-We lastly assume that all infections cause symptoms, and that 30% of symptomatic cases become hospitalised.
+We will make the following assumptions about the process from infection to hospital admission:
 
-::: {.callout-tip}
+-   Infection to symptoms:
+
+    -   We'll assume all infections cause symptoms.
+
+    -   *Time from infection to symptom onset (incubation period):* We assume that the incubation period is **gamma**-distributed with **shape 5** and **rate 1**, i.e. a mean of 5 days.
+
+-   Symptoms to hospital admission:
+
+    -   We'll assume that 30% of symptomatic cases become hospitalised.
+
+    -   *Time from symptom onset to hospital admission*: We assume that the onset-to-hospitalisation period is **lognormally** distributed, with **meanlog 1.75** and **sdlog 0.5**, corresponding to a mean delay of about a week.
+
+::: callout-tip
 ### Take 10 minutes
-Try to add onset and hospitalisation times (in decimal number of days after the first infection) to the infection data.
 
+Try to add onset and hospitalisation times (in decimal number of days after the first infection) to the infection data.
+:::
+
+::: {.callout-note collapse="true"}
+### Hints
+
+Tip 1: Create two new columns in the data: `onset_time` and `hosp_time`.
+Each column should add the new time (onset or admission) to the previous time (infection or onset), using random values from the correct probability distribution.
+Use the `rgamma` and `rlnorm` functions we used in the last session.
+
+Tip 2: Cases that don't become hospitalised should have missing (`NA`) values for the admission time.
+This is a binary (1/0) outcome, so try drawing from the binomial distribution with the `rbinom` function to create a random distribution of missing values in your column of admission times.
 :::
 
 ::: {.callout-note collapse="true"}
 ### Solution
+
 ```{r inf_hosp_solution, file = here::here("snippets", "onset-hosp.r")}
 ```
 :::
 
-Now we can plot infections, hospitalisations and onsets. To do so we first convert our data frame to long format.
+Now we can plot infections, hospitalisations and onsets.
+To do so we first convert our data frame to long format.
 
 ```{r plot_distributions, messages = FALSE}
 dfl <- df |>
@@ -95,6 +122,7 @@ ggplot(dfl, aes(x = time)) +
 
 As mentioned above, our data set of infection, onset and hospitalisation times is not the typical data set we encounter in outbreaks.
 In reality, we don't have infection dates, and we also have to deal with missing data, incomplete observations, data entry errors etc.
+
 For now, let us just assume we have a data set of symptom onset times and some hospitalisation times, and we would like to estimate how long it takes for people to become hospitalised after becoming symptomatic.
 This might be an important delay to know about, for example when modelling and forecasting hospitalisations, or more generally for estimating required hospital capacity.
 
@@ -104,31 +132,42 @@ To do this we can use a similar model to the one used in the [session on probabi
 mod <- cmdstan_model(here("stan", "lognormal.stan"))
 ```
 
-::: {.callout-tip}
+::: callout-tip
 ### Take 5 minutes
+
 Estimate the onset-to-hospitalisation delay using the simulated data set we created above.
 Do you recover the parameters used for simulation?
 :::
 
 ::: {.callout-note collapse="true"}
+### Hints
+
+Tip 1: First create a new column giving the time from onset to hospitalisation
+Tip 2: As in the last session, we can use our dataset to sample from the model posterior. Here we also need to exclude infections that didn't result in hospitalisation (try using `na.omit()` around the data).
+:::
+
+::: {.callout-note collapse="true"}
 ### Solution
 
-You can _sample_ from the model's posterior distribution by feeding it our simulated data set.
+You can *sample* from the model's posterior distribution by feeding it our simulated data set.
 
 ```{r sample_naive_delay_model, results = 'hide', message = FALSE, warning = FALSE}
-df_oth <- df |>
+## Time from onset to hospitalisation
+df_onset_to_hosp <- df |>
   mutate(onset_to_hosp = hosp_time - onset_time)
+## Use the data to sample from the model posterior
 res <- mod$sample(
   data = list(
-    n = nrow(na.omit(df_oth)),
-    y = na.omit(df_oth)$onset_to_hosp
+    n = nrow(na.omit(df_onset_to_hosp)),
+    y = na.omit(df_onset_to_hosp)$onset_to_hosp
   ),
   refresh = 0, show_exceptions = FALSE, show_messages = FALSE
 )
 ```
 
-::: {.callout-caution}
+::: callout-caution
 ### Reduce the amount of messages printed to the screen
+
 As before the arguments to `mod$sample()` after the `data` argument are there to remove the amount printed to the screen (and in this document).
 You can safely remove them.
 :::
@@ -139,7 +178,7 @@ To see the estimates, we can use:
 res$summary()
 ```
 
-These estimates should look similar to what we used in the simulations. 
+These estimates should look similar to what we used in the simulations.
 We can plot the resulting probability density functions.
 
 ```{r plot_onset_hospitalisation}
@@ -148,7 +187,7 @@ df <- res |>
   as_draws_df() |>
   filter(.draw %in% sample(.draw, 20)) ## sample 20 iterations randomly
 
-## find x that includes 99% of the cumulative density
+## find the value (x) that includes 99% of the cumulative density
 max_x <- max(qlnorm(0.99, meanlog = df$meanlog, sdlog = df$sdlog))
 
 ## calculate density on grid of x values
@@ -165,9 +204,6 @@ ggplot(df, aes(x = x, y = density, group = .draw)) +
 
 ## Going further
 
-- In this session we were in the enviable situation of knowing which distribution was used to generate the data. 
-With real data, of course, we don't have this information available.
-Try using a different distribution for inference (e.g. normal, or gamma).
-Do you get a good fit?
+-   In this session we were in the enviable situation of knowing which distribution was used to generate the data. With real data, of course, we don't have this information available. Try using a different distribution for inference (e.g. normal, or gamma). Do you get a good fit?
 
 ## Wrap up

--- a/sessions/delay-distributions.qmd
+++ b/sessions/delay-distributions.qmd
@@ -32,8 +32,13 @@ library("posterior")
 ## Simulating delayed epidemiological data
 
 We will start this session by working with a simulated data set of infections from a disease that has caused an outbreak which subsequently ended.
+In our example outbreak, there were 649 infections.
+The outbreak lasted around 90 days after the first infection, with new infections peaking roughly around day 40.
+
+::: callout-note
 For now we will not concern ourselves with the model used to generate the epidemic.
 This represents a typical situation in the real world, where we may have a model of how an infection has spread, but we don't know necessary know how well this corresponds to what really happened.
+:::
 
 We will later deal with modelling the infectious process.
 For now, we will focus on modelling how infections get reported in data - the *observation* process.
@@ -44,7 +49,7 @@ This has three issues:
 3.  These observations happen with a *delay* after the infection occurs (e.g. from infection to symptoms).
 
 We will work with a data set that is included in the `nfidd` R package that you installed initially.
-The column `infection_time` is a linelist of infections, given as a decimal number of days that have passed since the initial infection of the outbreak.
+The column `infection_time` is a linelist of infections from our example outbreak, given as a decimal number of days that have passed since the initial infection of the outbreak.
 It can be loaded with the `data` command.
 
 ```{r}
@@ -54,6 +59,7 @@ head(infection_times)
 ### visualise the infection curve
 ggplot(infection_times, aes(x = infection_time)) +
   geom_histogram(binwidth = 1) +
+  scale_x_continuous(n.breaks = 45) +
   xlab("Infection time (in days)") +
   ylab("Number of infections")
 ```
@@ -87,12 +93,12 @@ Try to add onset and hospitalisation times (in decimal number of days after the 
 ::: {.callout-note collapse="true"}
 ### Hints
 
-Tip 1: Create two new columns in the data: `onset_time` and `hosp_time`.
-Each column should add the new time (onset or admission) to the previous time (infection or onset), using random values from the correct probability distribution.
-Use the `rgamma` and `rlnorm` functions we used in the last session.
+1.  Create two new columns in the data: `onset_time` and `hosp_time`.
+    Each column should add the new time (onset or admission) to the previous time (infection or onset), using random values from the correct probability distribution.
+    Use the `rgamma` and `rlnorm` functions we used in the last session.
 
-Tip 2: Cases that don't become hospitalised should have missing (`NA`) values for the admission time.
-This is a binary (1/0) outcome, so try drawing from the binomial distribution with the `rbinom` function to create a random distribution of missing values in your column of admission times.
+2.  Cases that don't become hospitalised should have missing (`NA`) values for the admission time.
+    This is a binary (1/0) outcome, so try drawing from the binomial distribution with the `rbinom` function to create a random distribution of missing values in your column of admission times.
 :::
 
 ::: {.callout-note collapse="true"}
@@ -142,8 +148,8 @@ Do you recover the parameters used for simulation?
 ::: {.callout-note collapse="true"}
 ### Hints
 
-Tip 1: First create a new column giving the time from onset to hospitalisation
-Tip 2: As in the last session, we can use our dataset to sample from the model posterior. Here we also need to exclude infections that didn't result in hospitalisation (try using `na.omit()` around the data).
+Tip 1: First create a new column giving the time from onset to hospitalisation Tip 2: As in the last session, we can use our dataset to sample from the model posterior.
+Here we also need to exclude infections that didn't result in hospitalisation (try using `na.omit()` around the data).
 :::
 
 ::: {.callout-note collapse="true"}

--- a/sessions/slides/introduction-to-biases-in-epidemiological-delays.qmd
+++ b/sessions/slides/introduction-to-biases-in-epidemiological-delays.qmd
@@ -88,7 +88,7 @@ On the day of analysis we have not observed some delays yet, and these tended to
 ## `r fontawesome::fa("laptop-code", "white")` Your Turn {background-color="#447099" transition="fade-in"}
 
 - Simulate epidemiological delays with biases
-- Estimate parameters of a delay distribution, correcting for biaess
+- Estimate parameters of a delay distribution, correcting for biases
 
 [Return to the session](../biases-in-delay-distributions)
 

--- a/snippets/onset-hosp.r
+++ b/snippets/onset-hosp.r
@@ -1,3 +1,7 @@
+# Load data if not already loaded
+if(class(try(infection_times, silent=TRUE))=="try-error"){
+  load(here("data", "infection_times.rda"))}
+
 ### first, choose random delays
 df <- infection_times |>
   mutate(

--- a/snippets/onset-hosp.r
+++ b/snippets/onset-hosp.r
@@ -1,6 +1,5 @@
-# Load data if not already loaded
-if(class(try(infection_times, silent=TRUE))=="try-error"){
-  load(here("data", "infection_times.rda"))}
+# Load data
+data(infection_times)
 
 ### first, choose random delays
 df <- infection_times |>


### PR DESCRIPTION
Aim with this is to try and help the flow of ideas running through the sessions by adding some extra structure (bullet lists and paragraphs) and extra clarifications (e.g. reminders of the assumptions between sessions). 

Less sure of this but have also changed some dataframe names so they are easier to read: `df_oth` -> `df_onset_to_hosp` and `df_rt` -> `df_realtime` . This is mainly a style preference though so happy to put back.

Also fixing a few typos.

So far this includes delay + bias sessions: currently working through the others but opening in draft PR for now.