### PR TITLE
No rounding

### DIFF
--- a/functions/convolve-with-delay.r
+++ b/functions/convolve-with-delay.r
@@ -14,7 +14,7 @@ convolve_with_delay <- function(ts, delay) {
     pmf <- rev(delay)[seq_len(i - first_index + 1)]
     ## convolve with delay distribution
     ret <- sum(ts_segment * pmf)
-    return(round(ret))
+    return(ret)
   }, numeric(1))
   return(convolved)
 }

--- a/stan/functions/convolve_with_delay.stan
+++ b/stan/functions/convolve_with_delay.stan
@@ -10,5 +10,5 @@ array[] real convolve_with_delay(array[] real ts, array[] real delay) {
     array[i - first_index + 1] real ts_segment = ts[first_index:i];
     ret[i] = dot_product(ts_segment, pmf);
   }
-  return(round(ret));
+  return(ret);
 }


### PR DESCRIPTION
rounding makes the likelihood non-smooth which causes fitting issues as referenced in https://github.com/nfidd/nfidd/pull/112