### PR TITLE
Update geometric_random_walk.stan to use a for loop

### DIFF
--- a/stan/functions/geometric_random_walk.stan
+++ b/stan/functions/geometric_random_walk.stan
@@ -2,6 +2,8 @@ array[] real geometric_random_walk(real init, array[] real noise, real std) {
     int n = num_elements(noise) + 1;
     array[n] real x;
     x[1] = init;
-    x[2:n] = to_array_1d(init + cumulative_sum(to_vector(noise) * std));
+    for (i in 2:n) {
+        x[i] = x[i-1] + noise[i-1] * std;
+    }
     return exp(x);
 }


### PR DESCRIPTION
As discussed in #132 this PR moves to using a for loop for `geometric_random_walk` vs the cumulative sum formulation.