### PR TITLE
Add initial conditions for the random walk everywhere.

### DIFF
--- a/sessions/R-estimation-and-the-renewal-equation.qmd
+++ b/sessions/R-estimation-and-the-renewal-equation.qmd
@@ -349,10 +349,14 @@ data <- list(
 )
 r_rw_inf_fit <- rw_mod$sample(
   data = data, refresh = ifelse(interactive(), 50, 0), show_exceptions = FALSE, show_messages = FALSE,
-  parallel_chains = 4, max_treedepth = 12
+  parallel_chains = 4, max_treedepth = 12, init = \() list(init_R = 0, rw_sd = 0.01)
 )
 r_rw_inf_fit
 ```
+
+::: {.callout-tip}
+As this is a more complex model we have increased the `max_treedepth` parameter to 12 to allow for more complex posterior distributions and we have also provided an initialisation for the `init_R` and `rw_sd` parameters to help the sampler find the right region of parameter space. This is a common technique when fitting more complex models and is needed as it is hard a priori to know where the sampler should start.
+:::
 
 We can again extract and visualise the posteriors in the same way as earlier.
 

--- a/sessions/R-estimation-and-the-renewal-equation.qmd
+++ b/sessions/R-estimation-and-the-renewal-equation.qmd
@@ -351,7 +351,7 @@ data <- list(
 )
 r_rw_inf_fit <- rw_mod$sample(
   data = data, parallel_chains = 4, max_treedepth = 12, 
-  init = \() list(init_R = 0, rw_sd = 0.01
+  init = \() list(init_R = 0, rw_sd = 0.01)
 )
 ```
 

--- a/sessions/forecasting-concepts.qmd
+++ b/sessions/forecasting-concepts.qmd
@@ -138,7 +138,9 @@ data <- list(
   h = horizon # Here we set the number of days to forecast into the future
 )
 rw_forecast <- mod$sample(
-  data = data, parallel_chains = 4, refresh = 0, show_exceptions = FALSE, show_messages = FALSE, adapt_delta = 0.95)
+  data = data, parallel_chains = 4, refresh = 0, show_exceptions = FALSE, show_messages = FALSE, adapt_delta = 0.95,
+  init = \() list(init_R = 0, rw_sd = 0.01)
+)
 rw_forecast
 ```
 
@@ -215,7 +217,10 @@ long_data <- list(
 )
 
 rw_long <- mod$sample(
-  data = long_data, parallel_chains = 4, refresh = 0, show_exceptions = FALSE, show_messages = FALSE, adapt_delta = 0.95)
+  data = long_data, parallel_chains = 4, refresh = 0,
+  show_exceptions = FALSE, show_messages = FALSE, adapt_delta = 0.95,
+  init = \() list(init_R = 0, rw_sd = 0.01)
+  )
 ```
 
 We first need to extract the forecast and estimated reproduction numbers.

--- a/sessions/forecasting-concepts.qmd
+++ b/sessions/forecasting-concepts.qmd
@@ -138,7 +138,7 @@ data <- list(
   h = horizon # Here we set the number of days to forecast into the future
 )
 rw_forecast <- mod$sample(
-  data = data, parallel_chains = 4, adapt_delta = 0.95.
+  data = data, parallel_chains = 4, adapt_delta = 0.95,
   init = \() list(init_R = 0, rw_sd = 0.01)
 )
 ```

--- a/sessions/joint-nowcasting.qmd
+++ b/sessions/joint-nowcasting.qmd
@@ -258,7 +258,9 @@ joint_rt_data <- c(joint_data,
   )
 )
 joint_rt_fit <- joint_rt_mod$sample(
-  data = joint_rt_data, parallel_chains = 4, refresh = 0, show_exceptions = FALSE, show_messages = FALSE
+  data = joint_rt_data, parallel_chains = 4, refresh = 0,
+  show_exceptions = FALSE, show_messages = FALSE,
+  init = \() list(init_R = 0, rw_sd = 0.01)
 )
 joint_rt_fit
 ```

--- a/sessions/joint-nowcasting.qmd
+++ b/sessions/joint-nowcasting.qmd
@@ -259,7 +259,7 @@ joint_rt_data <- c(joint_data,
   )
 )
 joint_rt_fit <- joint_rt_mod$sample(
-  data = joint_rt_data, parallel_chains = 4.
+  data = joint_rt_data, parallel_chains = 4,
   init = \() list(init_R = 0, rw_sd = 0.01)
 )
 ```


### PR DESCRIPTION
This PR closes #131 by adding initial conditions for `init_R` and `rw_std`. I found that this was more stable than just doing so for `init_R` and didn't add any bias I could see.

I also added a note when we first do this explaining what we are doing. 

In this PR I did not update the forecasting models session as this is already covered in #207.