### PR TITLE
Make session slides all return in the same way

### DIFF
--- a/sessions/slides/convolutions.qmd
+++ b/sessions/slides/convolutions.qmd
@@ -72,4 +72,6 @@ where $F(t) = 0$ for $t \leq 0$.
 - Simulate convolutions with infection counts
 - Estimate parameters numbers of infections from number of symptom onsets, using a convolution model
 
+#
+
 [Return to the session](../biases-in-delay-distributions)

--- a/sessions/slides/forecasting-as-an-epidemiological-problem.qmd
+++ b/sessions/slides/forecasting-as-an-epidemiological-problem.qmd
@@ -82,4 +82,6 @@ Maximise *sharpness* subject to *calibration*
 1. Start with a simple model and use it to make a forecast (using stan)
 2. Evaluate the forecasts using proper scoring rules
 
+#
+
 [Return to the session](../forecasting-concepts)

--- a/sessions/slides/from-line-list-to-decisions.qmd
+++ b/sessions/slides/from-line-list-to-decisions.qmd
@@ -60,4 +60,6 @@ Throughout the course we will
 - applications (day 3)
 :::
 
+#
 
+[Return to the session](../introduction-and-course-overview)

--- a/sessions/slides/introduction-to-biases-in-epidemiological-delays.qmd
+++ b/sessions/slides/introduction-to-biases-in-epidemiological-delays.qmd
@@ -90,5 +90,7 @@ On the day of analysis we have not observed some delays yet, and these tended to
 - Simulate epidemiological delays with biases
 - Estimate parameters of a delay distribution, correcting for biases
 
+#
+
 [Return to the session](../biases-in-delay-distributions)
 

--- a/sessions/slides/introduction-to-epidemiological-delays.qmd
+++ b/sessions/slides/introduction-to-epidemiological-delays.qmd
@@ -166,4 +166,6 @@ ggplot(df, aes(x = x, y = density, group = id)) +
 - Simulate epidemiological delays
 - Estimate parameters of a delay distribution
 
+#
+
 [Return to the session](../delay-distributions)

--- a/sessions/slides/introduction-to-nowcasting.qmd
+++ b/sessions/slides/introduction-to-nowcasting.qmd
@@ -70,7 +70,7 @@ If we don't have individual-level data, we can estimate the delay distribution o
 2. Joint estimation of delay and nowcast
 3. Joint estimation of R_t, delay and nowcast
 
-###
+#
 
 [Return to the session](../nowcasting)
 

--- a/sessions/slides/introduction-to-reproduction-number.qmd
+++ b/sessions/slides/introduction-to-reproduction-number.qmd
@@ -77,4 +77,6 @@ What are some other ways of estimating it?
 -   Estimate reproduction numbers using a time series of infections
 -   Combine with delay distributions to jointly infer infections and R from a time series of outcomes
 
+#
+
 [Return to the session](../R-estimation-and-the-renewal-equation)


### PR DESCRIPTION
Closes #169 

I went through and checked all slides. The most common approach seems to be to make the return be on a new slide so I standardised to this