### PR TITLE
Standardise to use natural log

### DIFF
--- a/sessions/forecasting-concepts.qmd
+++ b/sessions/forecasting-concepts.qmd
@@ -328,7 +328,7 @@ rw_forecasts |>
   ggplot(aes(x = day)) +
   geom_line(aes(y = .value, group = interaction(.draw, target_day), col = target_day), alpha = 0.1) +
   geom_point(data = example_onset_df, aes(x = day, y = onsets), color = "black") +
-  scale_y_continuous(trans = "log") +
+  scale_y_log() +
   scale_color_binned(type = "viridis") +
   labs(title = "Weekly symptom onset forecasts: log scale",
        col = "Forecast start day")

--- a/sessions/forecasting-concepts.qmd
+++ b/sessions/forecasting-concepts.qmd
@@ -328,7 +328,7 @@ rw_forecasts |>
   ggplot(aes(x = day)) +
   geom_line(aes(y = .value, group = interaction(.draw, target_day), col = target_day), alpha = 0.1) +
   geom_point(data = example_onset_df, aes(x = day, y = onsets), color = "black") +
-  scale_y_log10() +
+  scale_y_continuous(trans = "log") +
   scale_color_binned(type = "viridis") +
   labs(title = "Weekly symptom onset forecasts: log scale",
        col = "Forecast start day")


### PR DESCRIPTION
We have a single (?) instance of plotting with log10 and otherwise use the natural log. I think the natural log makes more sense given that is the scale we are modelling on (and teaching epi processes on) but happy with either as long as we stick to one.