### PR TITLE
Improve stan output

### DIFF
--- a/sessions/R-Stan-and-statistical-concepts.qmd
+++ b/sessions/R-Stan-and-statistical-concepts.qmd
@@ -7,9 +7,13 @@ order: 1
 
 [Introduction to stan concepts used in the course](slides/introduction-to-stan)
 
-## Objectives
+# Objectives
 
 The aim of this session is to introduce the concept of probability distributions and how to estimate their parameters using Bayesian inference with `stan`.
+
+::: {.callout-note collapse="true"}
+
+# Setup
 
 ## Libraries used
 
@@ -29,7 +33,21 @@ The best way to interact with the material is via the [Visual Editor](https://do
 If not using the Visual Editor please remember that the code in the session needs to be run inside the course repository so that the `here()` commands below find the stan model files.
 :::
 
-## Simulating data from a probability distribution
+## Initialisation
+
+We set a random seed for reproducibility.
+Setting this ensures that you should get exactly the same results on your computer as we do.
+We also set an option that makes `cmstanr` show line numbers when printing model code.
+This is not strictly necessary but will help us talk about the models.
+
+```{r}
+set.seed(123)
+options(cmdstanr_print_line_numbers = TRUE)
+```
+
+:::
+
+# Simulating data from a probability distribution
 
 First let us simulate some data from a probability distribution.
 In R, this is usually done using a family of random number generation functions that start with `r`.
@@ -92,7 +110,7 @@ To do so, we first load in the model.
 ```{r load_gamma_model}
 ### load gamma model from the session directory
 mod <- cmdstan_model(here("stan", "gamma.stan"))
-### show model code with line numbers
+### show model code
 mod
 ```
 
@@ -113,14 +131,24 @@ Lines 3 and 4 define the data that has to be supplied to the model.
 We use the model we have defined in conjunction with the gamma distributed random numbers generated earlier to see if we can recover the parameters of the gamma distribution used.
 Once you have familiarised yourself with the model, use the `sample()` function to fit the model.
 
-```{r gamma_inference}
+```{r gamma_inference, results='hide', message=FALSE}
 stan_data <- list(
   N = length(gammas),
   y = gammas
 )
-gamma_fit <- mod$sample(
-  data = stan_data, refresh = 0, show_exceptions = FALSE, show_messages = FALSE
-)
+gamma_fit <- mod$sample(data = stan_data)
+```
+
+::: {.callout-note}
+### Stan messages
+The`mod$sample` command will produce a lot of messages which we have suppressed above.
+This is fine and intended to keep the user informed about any issues as well as general progress with the inference.
+This will come in handy later in the course when we fit more complicated models that can take a little while to run.
+:::
+
+In order to view a summary of the posterior samples generated, use
+
+```{r gamma_summary}
 gamma_fit
 ```
 

--- a/sessions/R-estimation-and-the-renewal-equation.qmd
+++ b/sessions/R-estimation-and-the-renewal-equation.qmd
@@ -349,7 +349,9 @@ data <- list(
   ip_pmf = ip_pmf,
   h = 0 # this is a small easter egg for the attentive reader
 )
-r_rw_inf_fit <- rw_mod$sample(data = data, parallel_chains = 4)
+r_rw_inf_fit <- rw_mod$sample(
+  data = data, parallel_chains = 4, max_treedepth = 12
+)
 ```
 
 ```{r r_inf_rw_fit_summary}

--- a/sessions/R-estimation-and-the-renewal-equation.qmd
+++ b/sessions/R-estimation-and-the-renewal-equation.qmd
@@ -349,9 +349,7 @@ data <- list(
   ip_pmf = ip_pmf,
   h = 0 # this is a small easter egg for the attentive reader
 )
-r_rw_inf_fit <- rw_mod$sample(
-  data = data, parallel_chains = 4, max_treedepth = 12
-)
+r_rw_inf_fit <- rw_mod$sample(data = data, parallel_chains = 4)
 ```
 
 ```{r r_inf_rw_fit_summary}

--- a/sessions/R-estimation-and-the-renewal-equation.qmd
+++ b/sessions/R-estimation-and-the-renewal-equation.qmd
@@ -164,7 +164,7 @@ Line 24 defines the prior distribution of R at each time point, and Line 25 defi
 
 Once again we can generate estimates from this model:
 
-```{r r_fit}
+```{r r_fit, results = 'hide', message = FALSE}
 data <- list(
   n = nrow(inf_ts) - 1,
   obs = inf_ts$infections[-1],
@@ -172,9 +172,10 @@ data <- list(
   gen_time_max = length(gen_time_pmf),
   gen_time_pmf = gen_time_pmf
 )
-r_fit <- mod$sample(
-  data = data, refresh = ifelse(interactive(), 50, 0), show_exceptions = FALSE, show_messages = FALSE
-)
+r_fit <- mod$sample(data = data, parallel_chains = 4)
+```
+
+```{r r_fit_summary}
 r_fit
 ```
 
@@ -231,7 +232,7 @@ How do the assumptions about the infections time series differ between the model
 
 We then generate estimates from this model:
 
-```{r r_inf_fit}
+```{r r_inf_fit, results = 'hide', message = FALSE}
 data <- list(
   n = length(obs) - 1,
   obs = obs[-1],
@@ -241,9 +242,10 @@ data <- list(
   ip_max = length(ip_pmf) - 1,
   ip_pmf = ip_pmf
 )
-r_inf_fit <- mod$sample(
-  data = data, refresh = ifelse(interactive(), 50, 0), show_exceptions = FALSE, show_messages = FALSE, parallel_chains = 4
-)
+r_inf_fit <- mod$sample(data = data, parallel_chains = 4)
+```
+
+```{r r_inf_fit_summary}
 r_inf_fit
 ```
 
@@ -336,7 +338,7 @@ Note that the model is very similar to the one we used earlier, but with the add
 
 We can now generate estimates from this model:
 
-```{r r_inf_rw_fit}
+```{r r_inf_rw_fit, results = 'hide', message = FALSE}
 data <- list(
   n = length(obs) - 1,
   obs = obs[-1],
@@ -348,9 +350,11 @@ data <- list(
   h = 0 # this is a small easter egg for the attentive reader
 )
 r_rw_inf_fit <- rw_mod$sample(
-  data = data, refresh = ifelse(interactive(), 50, 0), show_exceptions = FALSE, show_messages = FALSE,
-  parallel_chains = 4, max_treedepth = 12
+  data = data, parallel_chains = 4, max_treedepth = 12
 )
+```
+
+```{r r_inf_rw_fit_summary}
 r_rw_inf_fit
 ```
 

--- a/sessions/biases-in-delay-distributions.qmd
+++ b/sessions/biases-in-delay-distributions.qmd
@@ -121,15 +121,17 @@ Do you still recover the parameters that we put in?
 ::: {.callout-note collapse="true"}
 ## Solution
 
-```{r df_dates_solution}
+```{r df_dates_solution, results = 'hide', message = FALSE}
 mod <- cmdstan_model(here("stan", "lognormal.stan"))
 res <- mod$sample(
   data = list(
     n = nrow(na.omit(df_dates)),
     y = na.omit(df_dates)$onset_to_hosp
-  ),
-  refresh = 0, show_exceptions = FALSE, show_messages = FALSE
+  )
 )
+```
+
+```{r df_dates_solution_summary}
 res
 ```
 
@@ -164,14 +166,16 @@ Lines 15-17 reflect the integer delays, adjusted by the estimated times of day.
 
 Now we can use this model to re-estimate the parameters of the delay distribution:
 
-```{r censored_estimate}
+```{r censored_estimate, results = 'hide', message = FALSE}
 cres <- cmod$sample(
   data = list(
     n = nrow(na.omit(df_dates)),
     onset_to_hosp = na.omit(df_dates)$onset_to_hosp
-  ),
-  refresh = 0, show_exceptions = FALSE, show_messages = FALSE
+  )
 )
+```
+
+```{r censored_estimate_summary}
 cres
 ```
 
@@ -222,14 +226,16 @@ How far away from the "true" parameters do you end up?
 ::: {.callout-note collapse="true"}
 ## Solution
 
-```{r df_realtime_solution}
+```{r df_realtime_solution, results = 'hide', message = FALSE}
 res <- mod$sample(
   data = list(
     n = nrow(na.omit(df_realtime)),
     y = na.omit(df_realtime)$onset_to_hosp
-  ),
-  refresh = 0, show_exceptions = FALSE, show_messages = FALSE
+  )
 )
+```
+
+```{r df_realtime_solution_summary}
 res
 ```
 :::
@@ -256,15 +262,17 @@ Line 17 defines the upper limit of `onset_to_hosp` as `time_since_onset`.
 
 Now we can use this model to re-estimate the parameters of the delay distribution:
 
-```{r truncated_estimate}
+```{r truncated_estimate, results = 'hide', message = FALSE}
 tres <- tmod$sample(
   data = list(
     n = nrow(df_realtime),
     onset_to_hosp = df_realtime$onset_to_hosp, 
     time_since_onset = 70 - df_realtime$onset_time
-  ),
-  refresh = 0, show_exceptions = FALSE, show_messages = FALSE
+  )
 )
+```
+
+```{r truncated_estimate_summary}
 tres
 ```
 

--- a/sessions/delay-distributions.qmd
+++ b/sessions/delay-distributions.qmd
@@ -149,7 +149,7 @@ Let's estimate the onset-to-hospitalisation delay using the simulated data set w
 
 We can do this by *sampling* from the model's posterior distribution by feeding it our simulated data set.
 
-```{r sample_naive_delay_model, results = 'hide', message = FALSE, warning = FALSE}
+```{r sample_naive_delay_model, results = 'hide', message = FALSE}
 ## Specify the time from onset to hospitalisation
 df_onset_to_hosp <- df |>
   mutate(onset_to_hosp = hosp_time - onset_time) |> 
@@ -160,22 +160,14 @@ res <- mod$sample(
   data = list(
     n = nrow(df_onset_to_hosp),
     y = df_onset_to_hosp$onset_to_hosp
-  ),
-  refresh = 0, show_exceptions = FALSE, show_messages = FALSE
+  )
 )
 ```
-
-::: callout-caution
-## Reduce the amount of messages printed to the screen
-
-As before, the arguments to `mod$sample()` after the `data` argument are there to remove the amount of messages printed to the screen (and in this document).
-You can safely remove them.
-:::
 
 To see the estimates, we can use:
 
 ```{r summarise_naive_delay_model}
-res$summary()
+res$summary() ## could also simply type `res`
 ```
 
 These estimates should look similar to what we used in the simulations.

--- a/sessions/forecasting-concepts.qmd
+++ b/sessions/forecasting-concepts.qmd
@@ -124,7 +124,7 @@ tail(onset_df)
 We can now fit the model to the data and then make a forecast.
 This should look very similar to the code we used in the renewal session but with the addition of a non-zero `h` in the data list.
 
-```{r fit_model}
+```{r fit_model, results = 'hide', message = FALSE}
 horizon <- 28
 
 data <- list(
@@ -137,8 +137,10 @@ data <- list(
   ip_pmf = ip_pmf,
   h = horizon # Here we set the number of days to forecast into the future
 )
-rw_forecast <- mod$sample(
-  data = data, parallel_chains = 4, refresh = 0, show_exceptions = FALSE, show_messages = FALSE, adapt_delta = 0.95)
+rw_forecast <- mod$sample(data = data, parallel_chains = 4, adapt_delta = 0.95)
+```
+
+```{r rw_forecast_summary}
 rw_forecast
 ```
 
@@ -199,7 +201,7 @@ As our forecasting model is based on the reproduction number, we can also visual
 This can be helpful for understanding why our forecasts of symptom onsets look the way they do and for understanding the uncertainty in the forecasts.
 We can also compare this to the "true" reproduction number, estimated once all relevant data is available. To do this, we will fit the model again but with a later cutoff. Then we can compare the reproduction numbers produced as *forecasts* at the earlier time, with *estimates* at the later time that used more of the data.
 
-```{r fit_model_long}
+```{r fit_model_long, results = 'hide', message = FALSE}
 long_onset_df <- onset_df |>
   filter(day <= cutoff + horizon)
 
@@ -214,8 +216,7 @@ long_data <- list(
   h = 0
 )
 
-rw_long <- mod$sample(
-  data = long_data, parallel_chains = 4, refresh = 0, show_exceptions = FALSE, show_messages = FALSE, adapt_delta = 0.95)
+rw_long <- mod$sample(data = long_data, parallel_chains = 4, adapt_delta = 0.95)
 ```
 
 We first need to extract the forecast and estimated reproduction numbers.

--- a/sessions/forecasting-concepts.qmd
+++ b/sessions/forecasting-concepts.qmd
@@ -128,7 +128,7 @@ This should look very similar to the code we used in the renewal session but wit
 horizon <- 28
 
 data <- list(
-  n =nrow(filtered_onset_df),
+  n = nrow(filtered_onset_df),
   I0 = 1,
   obs = filtered_onset_df$onsets,
   gen_time_max = length(gen_time_pmf),
@@ -143,6 +143,11 @@ rw_forecast <- mod$sample(data = data, parallel_chains = 4, adapt_delta = 0.95)
 ```{r rw_forecast_summary}
 rw_forecast
 ```
+
+::: callout-note
+Because this model can struggle to fit to the data, we have increased the value of  `adapt_delta` from its default value of 0.8.
+This is, a tuning parameter that affects the step size of the sampler in exploring the posterior (higher `adapt_delta` leading to smaller step sizes meaning posterior exploration is slower but more careful).
+:::
 
 ## Visualising the forecast
 

--- a/sessions/forecasting-models.qmd
+++ b/sessions/forecasting-models.qmd
@@ -242,7 +242,7 @@ filtered_onset_df <- onset_df |>
 ```
 
 We will now fit the mechanistic model to the data.
-```{r fit_mech_model}
+```{r fit_mech_model, results = 'hide', message = FALSE}
 horizon <- 28
 
 data <- list(
@@ -257,13 +257,17 @@ data <- list(
   N_prior = c(10000, 2000) # the prior for the population size
 )
 mech_forecast_fit <- mech_mod$sample(
-  data = data, parallel_chains = 4, refresh = 0, show_exceptions = FALSE, show_messages = FALSE, adapt_delta = 0.95)
+  data = data, parallel_chains = 4, adapt_delta = 0.95
+)
+```
+
+```{r fit_mech_model_summary}
 mech_forecast_fit
 ```
 
 We will now fit the statistical model to the data.
 
-```{r fit_stat_model}
+```{r fit_stat_model, results = 'hide', message = FALSE}
 data <- list(
   n =nrow(filtered_onset_df),
   I0 = 1,
@@ -275,7 +279,8 @@ data <- list(
   h = horizon # Here we set the number of days to forecast into the future
 )
 stat_forecast_fit <- stat_mod$sample(
-  data = data, parallel_chains = 4, refresh = 0, show_exceptions = FALSE, show_messages = FALSE, adapt_delta = 0.9)
+  data = data, parallel_chains = 4, adapt_delta = 0.9
+)
 ```
 
 Finally we can extract the forecasts from the models and plot them.
@@ -326,7 +331,7 @@ In the above we assumed that we knew the population size roughly. In practice, w
 ::: {.callout-note, collapse = TRUE}
 ## The solution
 
-```{r}
+```{r very-wrong, results = 'hide', message = FALSE}
 data <- list(
   n =nrow(filtered_onset_df),
   I0 = 1,
@@ -340,12 +345,15 @@ data <- list(
 )
 
 mech_forecast_fit_diff <- mech_mod$sample(
-  data = data, parallel_chains = 4, refresh = 0, show_exceptions = FALSE, show_messages = FALSE, adapt_delta = 0.95)
+  data = data, parallel_chains = 4, adapt_delta = 0.95
+)
 
 mech_forecast_diff <- mech_forecast_fit_diff |>
   gather_draws(forecast[day]) |>
   mutate(day = day + cutoff)
+```
 
+```{r very-wrong-plot}
 mech_forecast_diff |>
   filter(.draw %in% sample(.draw, 1000)) |>
   ggplot(aes(y = .value, x = day)) +

--- a/sessions/joint-nowcasting.qmd
+++ b/sessions/joint-nowcasting.qmd
@@ -145,7 +145,7 @@ joint_mod
 
 and then fit it:
 
-```{r joint-nowcast-fit}
+```{r joint-nowcast-fit, results = 'hide', message = FALSE}
 joint_data <- list(
   n = length(unique(filtered_reporting_triangle$day)),                # number of days
   m = nrow(filtered_reporting_triangle),               # number of reports
@@ -157,9 +157,10 @@ joint_data <- list(
   obs = filtered_reporting_triangle$reported_onsets,     # observed symptom onsets
   d = 16               # number of reporting delays
 )
-joint_nowcast_fit <- joint_mod$sample(
-  data = joint_data, parallel_chains = 4, refresh = 0, show_exceptions = FALSE, show_messages = FALSE
-)
+joint_nowcast_fit <- joint_mod$sample(data = joint_data, parallel_chains = 4)
+```
+
+```{r joint-nowcast-fit-summary}
 joint_nowcast_fit
 ```
 
@@ -247,7 +248,7 @@ We would also remove the `generated quantities` block as we are not nowcasting t
 
 Now let's fit the final model for this session!
 
-```{r joint-nowcast-rt-fit}
+```{r joint-nowcast-rt-fit, results = 'hide', message = FALSE}
 joint_rt_data <- c(joint_data,
   list(
     gen_time_max = length(gen_time_pmf),
@@ -257,9 +258,10 @@ joint_rt_data <- c(joint_data,
     h = 0 # this is a small easter egg for the attentive reader
   )
 )
-joint_rt_fit <- joint_rt_mod$sample(
-  data = joint_rt_data, parallel_chains = 4, refresh = 0, show_exceptions = FALSE, show_messages = FALSE
-)
+joint_rt_fit <- joint_rt_mod$sample(data = joint_rt_data, parallel_chains = 4)
+```
+
+```{r joint-nowcast-rt-fit-summary}
 joint_rt_fit
 ```
 

--- a/sessions/nowcasting.qmd
+++ b/sessions/nowcasting.qmd
@@ -211,16 +211,17 @@ Familiarise yourself with the model above. What does it do?
 
 Once again we can generate estimates from this model:
 
-```{r nowcast_fit}
+```{r nowcast_fit, results = 'hide', message = FALSE}
 data <- list(
   n = nrow(reported_onset_df) - 1,
   obs = reported_onset_df$reported_onsets[-1],
   report_max = length(proportion_reported) - 1,
   report_cdf = proportion_reported 
 )
-simple_nowcast_fit <- mod$sample(
-  data = data, parallel_chains = 4, refresh = ifelse(interactive(), 50, 0), show_exceptions = FALSE, show_messages = FALSE
-)
+simple_nowcast_fit <- mod$sample(data = data, parallel_chains = 4)
+```
+
+```{r nowcast_fit_summary}
 simple_nowcast_fit
 ```
 
@@ -257,10 +258,11 @@ rw_mod
 
 and then fit it
 
-```{r rw-nowcast-fit}
-rw_nowcast_fit <- rw_mod$sample(
-  data = data, parallel_chains = 4, refresh = ifelse(interactive(), 50, 0), show_exceptions = FALSE, show_messages = FALSE
-)
+```{r rw-nowcast-fit, results = 'hide', message = FALSE}
+rw_nowcast_fit <- rw_mod$sample(data = data, parallel_chains = 4)
+```
+
+```{r rw-nowcast-fit-summary}
 rw_nowcast_fit
 ```
 
@@ -319,10 +321,11 @@ wrong_delay_data$report_cdf <- wrong_proportion_reported
 
 We now fit the nowcasting model with the wrong delay distribution:
 
-```{r gamma-nowcast-fit}
-gamma_nowcast_fit <- rw_mod$sample(
-  data = wrong_delay_data, parallel_chains = 4, refresh = ifelse(interactive(), 50, 0), show_exceptions = FALSE, show_messages = FALSE
-)
+```{r gamma-nowcast-fit, results = 'hide', message = FALSE}
+gamma_nowcast_fit <- rw_mod$sample(data = wrong_delay_data, parallel_chains = 4)
+```
+
+```{r gamma-nowcast-fit-summary}
 gamma_nowcast_fit
 ```
 

--- a/sessions/using-delay-distributions-to-model-the-data-generating-process-of-an-epidemic.qmd
+++ b/sessions/using-delay-distributions-to-model-the-data-generating-process-of-an-epidemic.qmd
@@ -203,24 +203,18 @@ Line 24 defines the likelihood, and it does so using the Poisson observation unc
 
 We can now use this model to conduct inference, i.e. to try to reconstruct the time series of infections from the time series of onsets that we generated earlier.
 
-```{r inf_fit}
+```{r inf_fit, results = 'hide', message = FALSE}
 data <- list(
   n = nrow(combined),
   obs = combined$observed,
   ip_max = length(gamma_pmf) - 1,
   ip_pmf = gamma_pmf
 )
-inf_fit <- mod$sample(
-  data = data,
-  refresh = 0, show_exceptions = FALSE, show_messages = FALSE
-)
+inf_fit <- mod$sample(data = data, parallel_chains = 4)
 ```
 
 ::: callout-caution
 Note that this code might take a few minutes to run.
-
-The arguments to `mod$sample()` after the `data` argument are there to remove the amount printed to the screen (and in this document).
-You can remove them and you'll get more messages from the stan sampler (which can be very useful for diagnosing and debugging).
 :::
 
 ::: callout-tip

--- a/sessions/using-delay-distributions-to-model-the-data-generating-process-of-an-epidemic.qmd
+++ b/sessions/using-delay-distributions-to-model-the-data-generating-process-of-an-epidemic.qmd
@@ -215,6 +215,8 @@ inf_fit <- mod$sample(data = data, parallel_chains = 4)
 
 ::: callout-caution
 Note that this code might take a few minutes to run.
+We have added the `parallel_chains` option to make use of any paralle hardware you may ave.
+If you don't have 4 computing cores and/or the code runs very slowly, you could try only running 2 chains (`chains = 2`) and/or fewer samples (`iter_warmup = 500, iter_sampling = 500`).
 :::
 
 ::: callout-tip


### PR DESCRIPTION
Improves the handling of stan sampling statements which now have suppressed outputs rather than random options.

Also adds an explainer of `parallel_chains` and `adapt_delta`. As we're only using `max_treedepth` once I have removed it there rather than explaining.

Closes #119 