### PR TITLE
Truncate Gamma priors.

### DIFF
--- a/stan/gamma.stan
+++ b/stan/gamma.stan
@@ -10,7 +10,7 @@ parameters {
 }
 
 model {
-  alpha ~ normal(0, 10);
-  beta ~ normal(0, 10);
+  alpha ~ normal(0, 10) T[0,];
+  beta ~ normal(0, 10) T[0,];
   y ~ gamma(alpha, beta);
 }


### PR DESCRIPTION
Closes #197 

I think it isn't totally needed as the lower = 0 already covers you but better practice and I think makes the prior a better representation of what you think