### PR TITLE
Downsample plots

### DIFF
--- a/sessions/R-estimation-and-the-renewal-equation.qmd
+++ b/sessions/R-estimation-and-the-renewal-equation.qmd
@@ -195,7 +195,7 @@ r_posterior <- r_fit |>
   gather_draws(R[infection_day]) |>
   ungroup() |>
   mutate(infection_day = infection_day - 1) |> 
-  filter(.draw %in% sample(.draw, 100)) # sample 100 trajectories for plotting
+  filter(.draw %in% sample(.draw, 100))
 
 ggplot(
   data = r_posterior,
@@ -266,7 +266,7 @@ r_inf_posteriors <- r_inf_fit |>
   gather_draws(infections[infection_day], R[infection_day]) |>
   ungroup() |>
   mutate(infection_day = infection_day - 1) |> 
-  filter(.draw %in% sample(.draw, 100)) # sample 100 trajectories for plotting
+  filter(.draw %in% sample(.draw, 100))
 ```
 
 We can visualise infections compared to the data used to generate the time series of onsets
@@ -377,7 +377,7 @@ rw_posteriors <- r_rw_inf_fit |>
   gather_draws(infections[infection_day], R[infection_day]) |>
   ungroup() |>
   mutate(infection_day = infection_day - 1) |>
-  filter(.draw %in% sample(.draw, 100)) # sample 100 trajectories for plotting
+  filter(.draw %in% sample(.draw, 100))
 ```
 
 ```{r plot_infections_rw}
@@ -397,7 +397,7 @@ and reproduction numbers
 ```{r plot_rt_rw}
 rw_r_inf_posterior <- rw_posteriors |>
   filter(.variable == "R") |>
-  filter(.draw %in% sample(.draw, 100)) ## extract 100 draws
+  filter(.draw %in% sample(.draw, 100))
 ggplot(
   data = rw_r_inf_posterior,
   mapping = aes(x = infection_day, y = .value, group = .draw)

--- a/sessions/delay-distributions.qmd
+++ b/sessions/delay-distributions.qmd
@@ -175,11 +175,15 @@ res$summary() ## could also simply type `res`
 These estimates should look similar to what we used in the simulations.
 We can plot the resulting probability density functions.
 
+:::{.callout note}
+Every time we sample from the model posterior, we create 4000 draws. That is a lot of data to plot, so instead, when we produce plots we'll use a random sample of 100 draws from the posterior each time. You'll see this throughout the course.
+:::
+
 ```{r plot_onset_hospitalisation}
 ## get shape and rate samples from the posterior
 res_df <- res |>
   as_draws_df() |>
-  filter(.draw %in% sample(.draw, 20)) ## sample 20 iterations randomly
+  filter(.draw %in% sample(.draw, 100))
 
 ## find the value (x) that includes 99% of the cumulative density
 max_x <- max(qlnorm(0.99, meanlog = res_df$meanlog, sdlog = res_df$sdlog))

--- a/sessions/delay-distributions.qmd
+++ b/sessions/delay-distributions.qmd
@@ -176,7 +176,7 @@ These estimates should look similar to what we used in the simulations.
 We can plot the resulting probability density functions.
 
 :::{.callout note}
-Every time we sample from the model posterior, we create 4000 draws. That is a lot of data to plot, so instead, when we produce plots we'll use a random sample of 100 draws from the posterior each time. You'll see this throughout the course.
+Every time we sample from the model posterior, we create 4000 iterations. That is a lot of data to plot, so instead, when we produce plots we'll use a random sample of 100 iterations. You'll see this throughout the course.
 :::
 
 ```{r plot_onset_hospitalisation}

--- a/sessions/delay-distributions.qmd
+++ b/sessions/delay-distributions.qmd
@@ -183,7 +183,7 @@ Every time we sample from the model posterior, we create 4000 draws. That is a l
 ## get shape and rate samples from the posterior
 res_df <- res |>
   as_draws_df() |>
-  filter(.draw %in% sample(.draw, 100))
+  filter(.draw %in% sample(.draw, 100)) # sample 100 draws
 
 ## find the value (x) that includes 99% of the cumulative density
 max_x <- max(qlnorm(0.99, meanlog = res_df$meanlog, sdlog = res_df$sdlog))

--- a/sessions/forecasting-models.qmd
+++ b/sessions/forecasting-models.qmd
@@ -310,7 +310,7 @@ target_onsets <- onset_df |>
 
 ```{r plot_forecast}
 forecast |>
-  filter(.draw %in% sample(.draw, 50)) |>
+  filter(.draw %in% sample(.draw, 100)) |>
   ggplot(aes(x = day)) +
   geom_line(alpha = 0.1, aes(y = .value, group = interaction(.draw, model), col = model)) +
   geom_point(data = target_onsets, aes(x = day, y = onsets), color = "black")
@@ -359,7 +359,7 @@ mech_forecast_diff <- mech_forecast_fit_diff |>
 
 ```{r very-wrong-plot}
 mech_forecast_diff |>
-  filter(.draw %in% sample(.draw, 1000)) |>
+  filter(.draw %in% sample(.draw, 100)) |>
   ggplot(aes(y = .value, x = day)) +
   geom_line(alpha = 0.1, aes(group = .draw)) +
   geom_point(
@@ -405,7 +405,7 @@ head(onset_df)
 
 ```{r plot-all-forecasts}
 forecasts |>
-  filter(.draw %in% sample(.draw, 50)) |>
+  filter(.draw %in% sample(.draw, 100)) |>
   ggplot(aes(x = day)) +
   geom_line(aes(y = .value, group = interaction(.draw, target_day), col = target_day), alpha = 0.1) +
   geom_point(data = onset_df |>
@@ -421,7 +421,7 @@ As for the single forecast it is helpful to also plot the forecast on the log sc
 
 ```{r plot-all-forecasts-log}
 forecasts |>
-  filter(.draw %in% sample(.draw, 50)) |>
+  filter(.draw %in% sample(.draw, 100)) |>
   ggplot(aes(x = day)) +
   geom_line(aes(y = .value, group = interaction(.draw, target_day), col = target_day), alpha = 0.1) +
   geom_point(data = onset_df, aes(x = day, y = onsets), color = "black") +

--- a/sessions/joint-nowcasting.qmd
+++ b/sessions/joint-nowcasting.qmd
@@ -180,7 +180,7 @@ We now extract this nowcast:
 joint_nowcast_onsets <- joint_nowcast_fit |>
   gather_draws(nowcast[day]) |>
   ungroup() |>
-  filter(.draw %in% sample(.draw, 100)) ## sample 100 iterations randomly
+  filter(.draw %in% sample(.draw, 100))
 ```
 
 Finally, we can plot the nowcast alongside the observed data:
@@ -281,7 +281,7 @@ First we can extract the nowcast and plot the nowcast alongside the observed dat
 joint_nowcast_with_r_onsets <- joint_rt_fit |>
   gather_draws(nowcast[day]) |>
   ungroup() |>
-  filter(.draw %in% sample(.draw, 100)) ## sample 100 iterations randomly
+  filter(.draw %in% sample(.draw, 100))
 ```
 
 ```{r plot-joint-nowcast-with-r}
@@ -296,7 +296,7 @@ We can also extract the reproduction number and plot it:
 joint_rt <- joint_rt_fit |>
   gather_draws(R[day]) |>
   ungroup() |>
-  filter(.draw %in% sample(.draw, 100)) ## sample 100 iterations randomly
+  filter(.draw %in% sample(.draw, 100))
 
 ggplot(joint_rt, aes(x = day, y = .value, group = .draw)) +
   geom_line(alpha = 0.1)

--- a/sessions/nowcasting.qmd
+++ b/sessions/nowcasting.qmd
@@ -239,7 +239,7 @@ We can now plot onsets alongside those nowcasted by the model:
 nowcast_onsets <- simple_nowcast_fit |>
   gather_draws(onsets[day]) |>
   ungroup() |>
-  filter(.draw %in% sample(.draw, 100)) |> ## sample 100 iterations randomly
+  filter(.draw %in% sample(.draw, 100)) |>
   mutate(day = day + 1)
 ```
 
@@ -344,7 +344,7 @@ Again we can extract the nowcast of symptom onsets and plot it alongside the obs
 gamma_nowcast_onsets <- gamma_nowcast_fit |>
   gather_draws(onsets[day]) |>
   ungroup() |>
-  filter(.draw %in% sample(.draw, 100)) |> ## sample 100 iterations randomly
+  filter(.draw %in% sample(.draw, 100)) |>
   mutate(day = day + 1)
 ```
 

--- a/sessions/using-delay-distributions-to-model-the-data-generating-process-of-an-epidemic.qmd
+++ b/sessions/using-delay-distributions-to-model-the-data-generating-process-of-an-epidemic.qmd
@@ -272,10 +272,7 @@ Does it look like a good fit?
 # Extract posterior draws
 inf_posterior <- inf_fit |>
   gather_draws(infections[infection_day]) |>
-  mutate(infection_day = infection_day - 1)
-
-# sample 100 trajectories for plotting
-inf_posterior <- inf_posterior |>
+  mutate(infection_day = infection_day - 1) |>
   filter(.draw %in% sample(.draw, 100))
 
 ggplot(mapping = aes(x = infection_day)) +


### PR DESCRIPTION
Should close #217

I notice in the forecasting concepts session some plots are set to [`.draws <= 50`](https://github.com/nfidd/nfidd/blob/61165c416d2b1d12937ea6bf7a34f9a5c180fef6/sessions/forecasting-concepts.qmd#L250). I haven't changed in case there's some reason for selecting the first 50 draws (rather than the random sample used elsewhere)? If no reason I'll update to match. 
