### PR TITLE
Issue 134: Add available data plotting to simple nowcasting session

### DIFF
--- a/sessions/joint-nowcasting.qmd
+++ b/sessions/joint-nowcasting.qmd
@@ -130,9 +130,7 @@ We also need to update our simulated truth data to include the Poisson observati
 
 ```{r update-simulated-onset}
 noisy_onsets_df <- reporting_triangle |>
-  group_by(day) |>
-  summarise(noisy_onsets = sum(reported_onsets)) |>
-  ungroup()
+  summarise(noisy_onsets = sum(reported_onsets), .by = day)
 ```
 
 As we only partially observe the reporting triangle we need to filter it to only include the data we have observed:
@@ -140,6 +138,13 @@ As we only partially observe the reporting triangle we need to filter it to only
 ```{r filter-reporting-triangle}
 filtered_reporting_triangle <- reporting_triangle |>
   filter(reported_day <= max(day))
+```
+
+Finally, we sum the filtered reporting triangle to get the counts we actually observe.
+
+```{r counts-observed}
+available_onsets <- filtered_reporting_triangle |>
+  summarise(available_onsets = sum(reported_onsets), .by = day)
 ```
 
 ## Fitting the joint model
@@ -187,9 +192,14 @@ Finally, we can plot the nowcast alongside the observed data:
 
 ```{r plot-joint-nowcast}
 ggplot(joint_nowcast_onsets, aes(x = day)) +
-  geom_col(data = noisy_onsets_df, mapping = aes(y = noisy_onsets)) +
-  geom_line(mapping = aes(y = .value, group = .draw), alpha = 0.1)
+  geom_col(data = noisy_onsets_df, mapping = aes(y = noisy_onsets), alpha = 0.6) +
+  geom_line(mapping = aes(y = .value, group = .draw), alpha = 0.1) +
+  geom_point(data = available_onsets, mapping = aes(y = available_onsets))
 ```
+
+:::{.callout-tip}
+Reminder: The points in this plot represent the data available when the nowcast was made (and so are truncated) whilst the bars represent the finally reported data (a perfect nowcast would exactly reproduce these).
+:::
 
 ::: {.callout-tip}
 ## Take 5 minutes
@@ -268,9 +278,14 @@ joint_rt_data <- c(joint_data,
 )
 joint_rt_fit <- joint_rt_mod$sample(
   data = joint_rt_data, parallel_chains = 4,
+  adapt_delta = 0.95,
   init = \() list(init_R = 0, rw_sd = 0.01)
 )
 ```
+
+::: {.callout-tip}
+We use `adapt_delta = 0.95` here as this is a relatively complex model with a difficult to explore posterior. Increasing this setting decreases the step size of the sampler and so makes it easier for it to explore the posterior. The downside is that fitting then takes longer.
+:::
 
 ```{r joint-nowcast-rt-fit-summary}
 joint_rt_fit
@@ -286,8 +301,9 @@ joint_nowcast_with_r_onsets <- joint_rt_fit |>
 
 ```{r plot-joint-nowcast-with-r}
 ggplot(joint_nowcast_with_r_onsets, aes(x = day)) +
-  geom_col(data = noisy_onsets_df, mapping = aes(y = noisy_onsets)) +
-  geom_line(mapping = aes(y = .value, group = .draw), alpha = 0.1)
+  geom_col(data = noisy_onsets_df, mapping = aes(y = noisy_onsets), alpha = 0.6) +
+  geom_line(mapping = aes(y = .value, group = .draw), alpha = 0.1) +
+  geom_point(data = available_onsets, mapping = aes(y = available_onsets))
 ```
 
 We can also extract the reproduction number and plot it:

--- a/sessions/nowcasting.qmd
+++ b/sessions/nowcasting.qmd
@@ -246,8 +246,13 @@ nowcast_onsets <- simple_nowcast_fit |>
 ```{r plot_nowcast}
 ggplot(nowcast_onsets, aes(x = day)) +
   geom_line(mapping = aes(y = .value, group = .draw), alpha = 0.1) +
-  geom_col(data = reported_onset_df, mapping = aes(y = onsets))
+  geom_col(data = reported_onset_df, mapping = aes(y = onsets), alpha = 0.6) +
+  geom_point(data = reported_onset_df, mapping = aes(y = reported_onsets))
 ```
+
+:::{.callout-tip}
+The points in this plot represent the data available when the nowcast was made (and so are truncated) whilst the bars represent the finally reported data (a perfect nowcast would exactly reproduce these).
+:::
 
 ::: {.callout-tip}
 As we found in the [using delay distributions to model the data generating process of an epidemic session](using-delay-distributions-to-model-the-data-generating-process-of-an-epidemic#estimating-a-time-series-of-infections), this simple model struggles to recreate the true number of onsets. This is because it does not capture the generative process of the data (i.e. the transmission process and delays from infection to onset). In the next section we will see how we can use a model that does capture this generative process to improve our nowcasts.
@@ -287,8 +292,9 @@ rw_nowcast_onsets <- rw_nowcast_fit |>
 
 ```{r rw-plot_nowcast}
 ggplot(rw_nowcast_onsets, aes(x = day)) +
-  geom_col(data = reported_onset_df, mapping = aes(y = onsets)) +
-  geom_line(mapping = aes(y = .value, group = .draw), alpha = 0.1)
+  geom_col(data = reported_onset_df, mapping = aes(y = onsets), alpha = 0.6) +
+  geom_line(mapping = aes(y = .value, group = .draw), alpha = 0.1) +
+  geom_point(data = reported_onset_df, mapping = aes(y = reported_onsets))
 ```
 
 ::: {.callout-tip}
@@ -350,8 +356,9 @@ gamma_nowcast_onsets <- gamma_nowcast_fit |>
 
 ```{r gamma-plot_nowcast}
 ggplot(gamma_nowcast_onsets, aes(x = day)) +
-  geom_col(data = reported_onset_df, mapping = aes(y = onsets)) +
-  geom_line(mapping = aes(y = .value, group = .draw), alpha = 0.1)
+  geom_col(data = reported_onset_df, mapping = aes(y = onsets), alpha = 0.6) +
+  geom_line(mapping = aes(y = .value, group = .draw), alpha = 0.1) +
+  geom_point(data = reported_onset_df, mapping = aes(y = reported_onsets))
 ```
 
 ::: {.callout-tip}


### PR DESCRIPTION
Closes #134 

Adds observed data plotting and a note explaining what is happening. Note I felt I needed to crank up adapt delta for the joint nowcast as it had an unacceptable number of divergent transitions (over 30%). Added a note on this.  I see a runtime of 2 minutes.