### PR TITLE
Reduce prior AR variance

### DIFF
--- a/stan/statistical-r.stan
+++ b/stan/statistical-r.stan
@@ -36,7 +36,7 @@ model {
   // priors
   init_R ~ normal(-.1, 0.5); // Approximately Normal(1, 0.5)
   rw_noise ~ std_normal();
-  rw_sd ~ normal(0, 0.05) T[0,];
+  rw_sd ~ normal(0, 0.01) T[0,];
   damp ~ normal(0.5, 0.25) T[0, 1];
   obs ~ poisson(onsets[1:n]);
 }

--- a/stan/statistical-r.stan
+++ b/stan/statistical-r.stan
@@ -36,7 +36,7 @@ model {
   // priors
   init_R ~ normal(-.1, 0.5); // Approximately Normal(1, 0.5)
   rw_noise ~ std_normal();
-  rw_sd ~ normal(0, 0.05) T[0,];
+  rw_sd ~ normal(0, 0.01) T[0,];
   damp ~ normal(0.25, 0.25) T[0, 1];
   obs ~ poisson(onsets[1:n]);
 }


### PR DESCRIPTION
Per @seabbs request, I'm proposing a tweak to the AR process's prior variance. I think the current process has slightly too much variance and it's hurting the model's predictive performance (Note: I can't get the scores to work in my installation due to some kind of a bug in loading scoringutils). 

After the change, the prior predictive Rt looks like so: 

![image](https://github.com/nfidd/nfidd/assets/46581799/0ab5d588-8d9b-4ba7-a8ed-16e2e8b02b3d)

The posterior for Rt looks like:

![image](https://github.com/nfidd/nfidd/assets/46581799/54169d61-0a81-497b-82f7-c42ee190679c)

In the current version on main the posterior looks like:

![image](https://github.com/nfidd/nfidd/assets/46581799/4c64949e-0739-4212-bf7a-e04f36ac24f7)

To my eye, the current posterior looks like it's shunting real changes in epidemic dynamics from the mean trend into the variance. I think that problem is rectified by the reduction in the prior AR variance, but fundamentally this prior is a subjective judgement call.
