### PR TITLE
Fix #293: Add mean/sd summaries to delays and biased delays sessions

### DIFF
--- a/sessions/biases-in-delay-distributions.qmd
+++ b/sessions/biases-in-delay-distributions.qmd
@@ -30,7 +30,7 @@ The source file of this session is located at `sessions/biases-in-delay-distribu
 
 ## Libraries used
 
-In this session we will use the `nfidd` package to load a data set of infection times and access stan models and helper functions, the `ggplot2` package for plotting, the `dplyr` and `tidyr` packages to wrangle data, the `lubridate` package to deal with dates.
+In this session we will use the `nfidd` package to load a data set of infection times and access stan models and helper functions, the `ggplot2` package for plotting, the `dplyr` and `tidyr` packages to wrangle data, the `lubridate` package to deal with dates, and the `tidybayes` package for extracting results from model fits.
 
 ```{r libraries, message = FALSE}
 library("nfidd")
@@ -38,6 +38,7 @@ library("ggplot2")
 library("dplyr")
 library("tidyr")
 library("lubridate")
+library("tidybayes")
 ```
 
 ::: callout-tip
@@ -148,6 +149,19 @@ res <- mod$sample(
 res
 ```
 
+We can calculate the mean and standard deviation to see the bias more clearly:
+
+```{r df_dates_mean_sd_summary}
+res |>
+  spread_draws(meanlog, sdlog) |>
+  mutate(
+    mean = exp(meanlog + 0.5 * sdlog^2),
+    sd = exp(meanlog + 0.5 * sdlog^2) * sqrt(exp(sdlog^2) - 1)
+  ) |>
+  select(mean, sd) |>
+  summary()
+```
+
 Usually the estimates will be further from the "true" parameters than before when we worked with the unrounded data.
 :::
 
@@ -190,6 +204,19 @@ cres <- cmod$sample(
 
 ```{r censored_estimate_summary}
 cres
+```
+
+We can also examine the mean and standard deviation of the estimated delay distribution:
+
+```{r censored_mean_sd_summary}
+cres |>
+  spread_draws(meanlog, sdlog) |>
+  mutate(
+    mean = exp(meanlog + 0.5 * sdlog^2),
+    sd = exp(meanlog + 0.5 * sdlog^2) * sqrt(exp(sdlog^2) - 1)
+  ) |>
+  select(mean, sd) |>
+  summary()
 ```
 
 ::: callout-tip
@@ -251,6 +278,19 @@ res <- mod$sample(
 ```{r df_realtime_solution_summary}
 res
 ```
+
+The mean and standard deviation show the underestimation due to truncation:
+
+```{r df_realtime_mean_sd_summary}
+res |>
+  spread_draws(meanlog, sdlog) |>
+  mutate(
+    mean = exp(meanlog + 0.5 * sdlog^2),
+    sd = exp(meanlog + 0.5 * sdlog^2) * sqrt(exp(sdlog^2) - 1)
+  ) |>
+  select(mean, sd) |>
+  summary()
+```
 :::
 
 Once again, we can write a model that adjusts for truncation, by re-creating the simulated truncation effect in the stan model:
@@ -287,6 +327,19 @@ tres <- tmod$sample(
 
 ```{r truncated_estimate_summary}
 tres
+```
+
+Let's also check the mean and standard deviation of the truncation-adjusted delay distribution:
+
+```{r truncated_mean_sd_summary}
+tres |>
+  spread_draws(meanlog, sdlog) |>
+  mutate(
+    mean = exp(meanlog + 0.5 * sdlog^2),
+    sd = exp(meanlog + 0.5 * sdlog^2) * sqrt(exp(sdlog^2) - 1)
+  ) |>
+  select(mean, sd) |>
+  summary()
 ```
 
 ::: callout-tip

--- a/sessions/delay-distributions.qmd
+++ b/sessions/delay-distributions.qmd
@@ -26,7 +26,7 @@ The source file of this session is located at `sessions/delay-distributions.qmd`
 
 ## Libraries used
 
-In this session we will use the `nfidd` package to load a data set of infection times and access stan models and helper functions, the `ggplot2` package for plotting, the `dplyr` and `tidyr` packages to wrangle data, the `lubridate` package to deal with dates, and the `posterior` packages for investigating the results of the inference conducted with stan.
+In this session we will use the `nfidd` package to load a data set of infection times and access stan models and helper functions, the `ggplot2` package for plotting, the `dplyr` and `tidyr` packages to wrangle data, the `lubridate` package to deal with dates, the `posterior` and `tidybayes` packages for investigating the results of the inference conducted with stan.
 
 ```{r libraries, message = FALSE}
 library("nfidd")
@@ -35,6 +35,7 @@ library("dplyr")
 library("tidyr")
 library("lubridate")
 library("posterior")
+library("tidybayes")
 ```
 
 ::: {.callout-tip}
@@ -187,6 +188,21 @@ res$summary() ## could also simply type `res`
 ```
 
 These estimates should look similar to what we used in the simulations.
+
+We can also calculate the mean and standard deviation of the lognormal distribution from the estimated parameters:
+
+```{r mean_sd_summary}
+res |>
+  spread_draws(meanlog, sdlog) |>
+  mutate(
+    mean = exp(meanlog + 0.5 * sdlog^2),
+    sd = exp(meanlog + 0.5 * sdlog^2) * sqrt(exp(sdlog^2) - 1)
+  ) |>
+  select(mean, sd) |>
+  summary()
+```
+
+This shows us the mean and standard deviation of the onset-to-hospitalisation delay in days, which is often more interpretable than the lognormal parameters.
 We can plot the resulting probability density functions.
 
 ::: {.callout-note}


### PR DESCRIPTION
## Summary
- Adds mean and standard deviation calculations to delay distribution sessions
- Fixes mathematical formula for lognormal standard deviation from the issue
- Includes tidybayes library dependency for both sessions

## Changes Made
- **delay-distributions.qmd**: Added mean/sd summary after model results with contextual explanation
- **biases-in-delay-distributions.qmd**: Added mean/sd summaries after naive, censored, and truncated model results
- Added `tidybayes` library to both sessions for `spread_draws` function
- Corrected the standard deviation formula: `sd = exp(meanlog + 0.5 * sdlog^2) * sqrt(exp(sdlog^2) - 1)`

## Testing Performed
- Both sessions render successfully with `quarto render`
- Mathematical formulas verified against lognormal distribution properties
- Code executes without errors and produces expected summary outputs

## Link to Issue
Closes #293

🤖 Generated with [Claude Code](https://claude.ai/code)