### PR TITLE
Timetable links

### DIFF
--- a/sessions.qmd
+++ b/sessions.qmd
@@ -5,18 +5,18 @@ comments: false
 
 # Day 1: Deconstructing epidemiological timelines
 
-**Monday June 24**
+**Monday June 23**
 
 ## Session 0: Introduction and course overview
 
-09.00-09.30
+Monday June 23: 09.00-09.30
 
 -   [Introduction](introduction-to-the-course-and-the-instructors.qmd): the course and the instructors (10 mins)
 -   [Motivating the course](from-line-list-to-decisions.qmd): From an epidemiological line list to informing decisions in real-time (20 mins)
 
 ## Session 1: R, Stan, and statistical concept background
 
-09.30-10.30
+Monday June 23: 09.30-10.30
 
 -   [Introduction](sessions/slides/introduction-to-statistical-concepts): statistical concepts used in the course (15 mins)
 -   [Introduction](sessions/slides/introduction-to-stan): stan concepts used in the course (15 mins)
@@ -24,7 +24,7 @@ comments: false
 
 ## Session 2: Delay distributions
 
-11.00-11.45
+Monday June 23: 11.00-11.45
 
 -   [Introduction](sessions/slides/introduction-to-epidemiological-delays.qmd): epidemiological delays and how to represent them with probability distributions (10 mins)
 -   [Practice](delay-distributions.qmd): simulate and estimate epidemiological delays (30 mins)
@@ -32,7 +32,7 @@ comments: false
 
 ## Session 3: Biases in delay distributions
 
-11.45-12.30 and 14.00-14.45
+Monday June 23: 11.45-12.30 and 14.00-14.45
 
 -   [Introduction](sessions/slides/introduction-to-biases-in-epidemiological-delays.qmd): biases in delay distributions (10 mins)
 -   [Practice](sessions/biases-in-delay-distributions.qmd): 
@@ -42,14 +42,14 @@ comments: false
 
 ## Session 4: Using delay distributions to model the data generating process of an epidemic
 
-14.45-15.30
+Monday June 23: 14.45-15.30
 
 -   [Introduction](convolutions.qmd): Using delay distributions to model the data generating process of an epidemic (15 mins)
 -   [Practice](sessions/using-delay-distributions-to-model-the-data-generating-process-of-an-epidemic.qmd): implementing a convolution model and identifying potential problems (30 mins)
 
 ## Session 5: $R_t$ estimation and the renewal equation
 
-16.00-17.30
+Monday June 23: 16.00-17.30
 
 -   [Introduction](sessions/slides/introduction-to-reproduction-number.qmd): the time-varying reproduction number (10 mins)
 -   [Practice](sessions/R-estimation-and-the-renewal-equation.qmd): 
@@ -59,15 +59,15 @@ comments: false
 
 # Day 2: Constructing nowcasts and forecasts
 
-**Tuesday June 25**
+**Tuesday June 24**
 
-09.00-09.15
+Tuesday June 24: 09.00-09.15
 
 -   Day 1 review
 
 ## Session 6: Nowcasting concepts
 
-09.15-10.30
+Tuesday June 24: 09.15-10.30
 
 -   [Introduction](sessions/slides/introduction-to-nowcasting.qmd): nowcasting as a right-truncation problem (10 mins)
 -   [Practice](sessions/nowcasting.qmd): 
@@ -77,7 +77,7 @@ comments: false
 
 ## Session 7: Nowcasting with an unknown reporting delay
 
-11.00-12.30
+Tuesday June 24: 11.00-12.30
 
 -   [Introduction](sessions/slides/introduction-to-joint-estimation-of-nowcasting-and-reporting-delays.qmd): joint estimation of delays and nowcasts (10 mins)
 -   [Practice](sessions/joint-nowcasting.qmd):
@@ -87,7 +87,7 @@ comments: false
 
 ## Session 8: Forecasting concepts
 
-14.00-15.30
+Tuesday June 24: 14.00-15.30
 
 -   [Introduction](sessions/slides/forecasting-as-an-epidemiological-problem.qmd): forecasting as an epidemiological problem, and its relationship with nowcasting and $R_t$ estimation (10 mins)
 -   [Practice](sessions/forecast-visualisation.qmd): 
@@ -97,7 +97,7 @@ comments: false
 
 ## Session 9: Forecasting models
 
-16.00-17.30
+Tuesday June 24: 16.00-17.30
 
 -   [Introduction](sessions/slides/forecast-evaluation.qmd): quantitatively evaluating forecasts (10 mins)
 -   [Practice](sessions/forecast-evaluation.qmd): evaluating forecasts with a range of metrics (60 mins)
@@ -108,28 +108,28 @@ comments: false
 
 # Day 3: Reconstructing - ensembles and applications
 
-**Wednesday June 26**
+**Wednesday June 25**
 
-09.00-09.15
+Wednesday June 25: 09.00-09.15
 
 -   Day 2 review
 
 ## Session 10: Forecasting with ensembles
 
-09.15-10.30
+Wednesday June 25: 09.15-10.30
 
 -   [Introduction](sessions/slides/introduction-to-ensembles.qmd): strategies for collating and combining models
 -   [Practice](sessions/forecast-ensembles): evaluating methods for ensemble forecasts
 
 ## Session 11: Methods in the real world
 
-11.00-12.00
+Wednesday June 25: 11.00-12.00
 
 -   Presentations and Q&A on uses of nowcasts & forecasts in the real world (60 mins)
 
 ## Session 12: End of course summary
 
-12.00-12.30
+Wednesday June 25: 12.00-12.30
 
 -   [Summary](sessions/slides/closing.qmd) of the course (10 mins)
 -   Final discussion and closing (20 mins)

--- a/sessions.qmd
+++ b/sessions.qmd
@@ -3,108 +3,134 @@ title: "Sessions"
 comments: false
 ---
 
+# Day 1: Deconstructing epidemiological timelines
+
+**Monday June 24**
+
 ## Session 0: Introduction and course overview
 
-Monday June 24: 9.00-9.30
+09.00-09.30
 
-- Introduction to the course and the instructors (10 mins)
-- Motivating the course: From an epidemiological line list to informing decisions in real-time (20 mins)
+-   [Introduction](introduction-to-the-course-and-the-instructors.qmd): the course and the instructors (10 mins)
+-   [Motivating the course](from-line-list-to-decisions.qmd): From an epidemiological line list to informing decisions in real-time (20 mins)
 
 ## Session 1: R, Stan, and statistical concept background
 
-Monday June 24: 9.30-10.30
+09.30-10.30
 
-- Introduction to statistical concepts used in the course (15 mins)
-- Introduction to stan concepts used in the course (15 mins)
-- Practice session: introduction to estimation in stan (30 mins)
+-   [Introduction](sessions/slides/introduction-to-statistical-concepts): statistical concepts used in the course (15 mins)
+-   [Introduction](sessions/slides/introduction-to-stan): stan concepts used in the course (15 mins)
+-   [Practice](sessions/R-Stan-and-statistical-concepts): introduction to estimation in stan (30 mins)
 
 ## Session 2: Delay distributions
 
-Monday June 24: 11.00-11.45
+11.00-11.45
 
-- Introduction to epidemiological delays and how to represent them with probability distributions (10 mins)
-- Practice session: simulate and estimate epidemiological delays (30 mins)
-- Wrap up (5 mins)
+-   [Introduction](sessions/slides/introduction-to-epidemiological-delays.qmd): epidemiological delays and how to represent them with probability distributions (10 mins)
+-   [Practice](delay-distributions.qmd): simulate and estimate epidemiological delays (30 mins)
+-   Wrap up (5 mins)
 
 ## Session 3: Biases in delay distributions
 
-Monday June 24: 11.45-12.30 and 14.00-14.45
+11.45-12.30 and 14.00-14.45
 
-- Introduction to biases in delay distributions (10 mins)
-- Practice session: Simulating biases in delay distributions and estimating delays without adjustment on these data (35 mins)
-- Practice session: estimating delay distributions with adjustments for bias (35 mins)
-- Wrap up (10 mins)
+-   [Introduction](sessions/slides/introduction-to-biases-in-epidemiological-delays.qmd): biases in delay distributions (10 mins)
+-   [Practice](sessions/biases-in-delay-distributions.qmd): 
+    - simulating biases in delay distributions and estimating delays without adjustment on these data (35 mins)
+    - estimating delay distributions with adjustments for bias (35 mins)
+-   Wrap up (10 mins)
 
 ## Session 4: Using delay distributions to model the data generating process of an epidemic
 
-Monday June 24: 14.45-15.30
+14.45-15.30
 
-- Using delay distributions to model the data generating process of an epidemic (15 mins)
-- Practice session: implementing a convolution model and identifying potential problems (30 mins)
+-   [Introduction](convolutions.qmd): Using delay distributions to model the data generating process of an epidemic (15 mins)
+-   [Practice](sessions/using-delay-distributions-to-model-the-data-generating-process-of-an-epidemic.qmd): implementing a convolution model and identifying potential problems (30 mins)
 
 ## Session 5: $R_t$ estimation and the renewal equation
 
-Monday June 24: 16.00-17.30
+16.00-17.30
 
-- Introduction to the time-varying reproduction number (10 mins)
-- Practice session: using the renewal equation to estimate R (35 mins)
-- Practice session: combining $R_t$ estimation with delay distribution convolutions (35 mins)
-- Wrap up (10 mins)
+-   [Introduction](sessions/slides/introduction-to-reproduction-number.qmd): the time-varying reproduction number (10 mins)
+-   [Practice](sessions/R-estimation-and-the-renewal-equation.qmd): 
+    - using the renewal equation to estimate R (35 mins)
+    - combining $R_t$ estimation with delay distribution convolutions (35 mins)
+-   Wrap up (10 mins)
+
+# Day 2: Constructing nowcasts and forecasts
+
+**Tuesday June 25**
+
+09.00-09.15
+
+-   Day 1 review
 
 ## Session 6: Nowcasting concepts
 
-Tuesday June 25: 9.00-10.30
+09.15-10.30
 
-- Introduction to nowcasting as a right-truncation problem (10 mins)
-- Practice session: Simulating the delay distribution (35 mins)
-- Practice session: Nowcasting using pre-estimated delay distributions (35 mins)
-- Wrap up (10 mins)
+-   [Introduction](sessions/slides/introduction-to-nowcasting.qmd): nowcasting as a right-truncation problem (10 mins)
+-   [Practice](sessions/nowcasting.qmd): 
+    - simulating the delay distribution (35 mins)
+    - nowcasting using pre-estimated delay distributions (35 mins)
+-   Wrap up (10 mins)
 
 ## Session 7: Nowcasting with an unknown reporting delay
 
-Tuesday June 25: 11.00-12.30
+11.00-12.30
 
-- Introduction to joint estimation of delays and nowcasts (10 mins)
-- Practice session: Joint estimation of delays and nowcasts (35 mins)
-- Practice session: Joint estimation of delays, nowcasts and reproduction numbers (35 mins)
-- Wrap up (10 mins)
+-   [Introduction](sessions/slides/introduction-to-joint-estimation-of-nowcasting-and-reporting-delays.qmd): joint estimation of delays and nowcasts (10 mins)
+-   [Practice](sessions/joint-nowcasting.qmd):
+    - joint estimation of delays and nowcasts (35 mins)
+    - joint estimation of delays, nowcasts and reproduction numbers (35 mins)
+-   Wrap up (10 mins)
 
 ## Session 8: Forecasting concepts
 
-Tuesday June 25: 14.00-15.30
+14.00-15.30
 
-- Introduction to forecasting as an epidemiological problem, and its relationship with nowcasting and $R_t$ estimation (10 mins)
-- Practice session: extending a model into the future (35 minutes)
-- Practice session: evaluate your forecast (35 mins)
-- Wrap up (10 mins)
+-   [Introduction](sessions/slides/forecasting-as-an-epidemiological-problem.qmd): forecasting as an epidemiological problem, and its relationship with nowcasting and $R_t$ estimation (10 mins)
+-   [Practice](sessions/forecast-visualisation.qmd): 
+    - extending a model into the future (35 minutes)
+    - visualising and evaluating your forecast (35 mins)
+-   Wrap up (10 mins)
 
 ## Session 9: Forecasting models
 
-Tuesday June 25: 16.00-17.30
+16.00-17.30
 
-- An overview of forecasting models (10 mins)
-- Practice session: Evaluating forecasts from a range of models (60 mins)
-- Wrap up and discussion (20 mins)
+-   [Introduction](sessions/slides/forecast-evaluation.qmd): quantitatively evaluating forecasts (10 mins)
+-   [Practice](sessions/forecast-evaluation.qmd): evaluating forecasts with a range of metrics (60 mins)
+-   Wrap up and discussion (20 mins)
 
-## Session 10: Examples of available tools
+-   [Introduction](sessions/slides/introduction-to-the-spectrum-of-forecasting-models.qmd): a spectrum of forecasting models
+-   [Practice](sessions/forecasting-models.qmd): evaluating forecasts from a range of models
 
-Tuesday June 25: 9.00-10.30
+# Day 3: Reconstructing - ensembles and applications
 
-- Introduction to tools for $R_t$ estimation, nowcasting and forecasting (5 mins)
-- Group work: explore a tool and relate it to key concepts in the course (30 mins)
-- Discussion (15 mins)
-- Individual exploration of all packages (35 mins)
-- Wrap up (5 mins)
+**Wednesday June 26**
+
+09.00-09.15
+
+-   Day 2 review
+
+## Session 10: Forecasting with ensembles
+
+09.15-10.30
+
+-   [Introduction](sessions/slides/introduction-to-ensembles.qmd): strategies for collating and combining models
+-   [Practice](sessions/forecast-ensembles): evaluating methods for ensemble forecasts
 
 ## Session 11: Methods in the real world
 
-Wednesday June 26: 11.00-12.00
+11.00-12.00
 
-- Presentations and Q&A on uses of nowcasts & forecasts in the real world (60 mins)
+-   Presentations and Q&A on uses of nowcasts & forecasts in the real world (60 mins)
 
 ## Session 12: End of course summary
 
-Wednesday June 26: 12.00-12.30
+12.00-12.30
 
-- Summary of the course (10 mins)
-- Final discussion and closing (20 mins)
+-   [Summary](sessions/slides/closing.qmd) of the course (10 mins)
+-   Final discussion and closing (20 mins)
+    - [Further reading](end-of-course-summary-and-discussion.qmd)


### PR DESCRIPTION
Adds links to the slides and practicals directly in the timetable.

Addresses some of #404 but not everything:
- [x] Remove "Examples of available tools" session from timeline (keep the package)
- [x] Add ensembles session to the timetable
- [x] Add 15-minute morning catch-up at start of each day (except Day 1)
- [ ] Shorten Session 6 to accommodate other changes
- [x] Update all dates for 2025
- [ ] Review and update session timings

Especially flagging that Tuesday afternoon in the current timetable, we don't have the session on the range of forecasting models. But this is anyway referred to in the ensemble session so need it somewhere. I've added to the timetable in this PR so all the content is there, we just need to play around with the timings. 

Hence opening as a draft.