### PR TITLE
streamline use of logged and natural R

### DIFF
--- a/R/geometric-diff-ar.r
+++ b/R/geometric-diff-ar.r
@@ -20,7 +20,7 @@ geometric_diff_ar <- function(init, noise, std, damp) {
   ## declare vector
   x <- numeric(n)
   ## initial value
-  x[1] <- init
+  x[1] <- log(init)
   ## second value (no difference yet available for use)
   x[2] <- x[1] + noise[1] * std
   ## random walk

--- a/R/geometric-random-walk.r
+++ b/R/geometric-random-walk.r
@@ -18,7 +18,7 @@ geometric_random_walk <- function(init, noise, std) {
   ## declare vector
   x <- numeric(n)
   ## initial value
-  x[1] <- init
+  x[1] <- log(init)
   ## random walk
   for (i in 2:n) {
     x[i] <- x[i - 1] + noise[i - 1] * std

--- a/data-raw/generate-example-forecasts.r
+++ b/data-raw/generate-example-forecasts.r
@@ -39,7 +39,7 @@ forecast_target_day <- function(
     mutate(horizon = day) |>
     mutate(day = day + target_day) |>
     mutate(target_day = target_day) |>
-    mutate(.draw = seq_leon(n())) |>
+    mutate(.draw = seq_len(n())) |>
     select(-.chain, -.iteration)
 }
 

--- a/data-raw/generate-example-forecasts.r
+++ b/data-raw/generate-example-forecasts.r
@@ -75,7 +75,7 @@ rw_forecasts <- target_days |>
     \(x) {
       forecast_target_day(
         rw_mod, onset_df, x, horizon, gen_time_pmf, ip_pmf,
-        data_to_list_rw, init = \() list(init_R = 0, rw_sd = 0.01)
+        data_to_list_rw, init = \() list(init_R = 1, rw_sd = 0.01)
       )
     }
   ) |>
@@ -92,7 +92,7 @@ stat_forecasts <- target_days |>
     \(x) {
       forecast_target_day(
         stat_mod, onset_df, x, horizon, gen_time_pmf, ip_pmf, data_to_list_rw,
-        init = \() list(init_R = 0, rw_sd = 0.01)
+        init = \() list(init_R = 1, rw_sd = 0.01)
       )
     }
   ) |>

--- a/inst/stan/estimate-inf-and-r-rw-forecast.stan
+++ b/inst/stan/estimate-inf-and-r-rw-forecast.stan
@@ -20,7 +20,7 @@ transformed data {
 }
 
 parameters {
-  real<lower = -1, upper = 1> init_R;         // initial reproduction number
+  real<lower = 0> init_R;         // initial reproduction number
   array[m-1] real rw_noise; // random walk noise
   real<lower = 0, upper = 1> rw_sd; // random walk standard deviation
 }
@@ -33,7 +33,7 @@ transformed parameters {
 
 model {
   // priors
-  init_R ~ normal(-0.1, 0.5); // Approximately Normal(1, 0.5)
+  init_R ~ normal(1, 0.5) T[0, ];
   rw_noise ~ std_normal();
   rw_sd ~ normal(0, 0.05) T[0,];
   obs ~ poisson(onsets[1:n]);

--- a/inst/stan/estimate-inf-and-r-rw.stan
+++ b/inst/stan/estimate-inf-and-r-rw.stan
@@ -15,7 +15,7 @@ data {
 }
 
 parameters {
-  real init_R;         // initial reproduction number
+  real<lower = 0> init_R;         // initial reproduction number
   array[n-1] real rw_noise; // random walk noise
   real<lower = 0> rw_sd; // random walk standard deviation
 }
@@ -28,8 +28,8 @@ transformed parameters {
 
 model {
   // priors
-  init_R ~ normal(-0.1, 0.5); // Approximately Normal(1, 0.5)
+  init_R ~ normal(1, 0.5) T[0, ];
   rw_noise ~ std_normal();
-  rw_sd ~ normal(0, 0.05) T[0,];
+  rw_sd ~ normal(0, 0.05) T[0, ];
   obs ~ poisson(onsets);
 }

--- a/inst/stan/functions/geometric_diff_ar.stan
+++ b/inst/stan/functions/geometric_diff_ar.stan
@@ -1,8 +1,8 @@
 array[] real geometric_diff_ar(real init, array[] real noise, real std, real damp) {
     int n = num_elements(noise) + 1;
     array[n] real x;
-    x[1] = init;
-    x[2] = init + noise[1] * std;
+    x[1] = log(init);
+    x[2] = x[1] + noise[1] * std;
     for (i in 3:n) {
         x[i] = x[i - 1] + damp * (x[i -1] - x[i- 2]) + noise[i - 1] * std;
     }

--- a/inst/stan/functions/geometric_random_walk.stan
+++ b/inst/stan/functions/geometric_random_walk.stan
@@ -1,7 +1,7 @@
 array[] real geometric_random_walk(real init, array[] real noise, real std) {
     int n = num_elements(noise) + 1;
     array[n] real x;
-    x[1] = init;
+    x[1] = log(init);
     for (i in 2:n) {
         x[i] = x[i-1] + noise[i-1] * std;
     }

--- a/inst/stan/joint-nowcast-with-r.stan
+++ b/inst/stan/joint-nowcast-with-r.stan
@@ -25,7 +25,7 @@ transformed data{
 
 parameters {
   real<lower = 0> init_I;         // initial number of infected
-  real init_R;         // initial reproduction number
+  real<lower = 0> init_R;         // initial reproduction number
   array[n-1] real rw_noise;       // random walk noise
   real<lower = 0> rw_sd; // random walk standard deviation
   simplex[d] reporting_delay; // reporting delay distribution
@@ -41,7 +41,7 @@ transformed parameters {
 model {
   // Prior
   init_I ~ lognormal(-1, 1);
-  init_R ~ normal(-0.1, 0.5); // Approximately Normal(1, 0.5)
+  init_R ~ normal(1, 0.5) T[0, ];
   rw_noise ~ std_normal();
   rw_sd ~ normal(0, 0.05) T[0,];
   reporting_delay ~ dirichlet(rep_vector(1, d));

--- a/inst/stan/statistical-r.stan
+++ b/inst/stan/statistical-r.stan
@@ -34,7 +34,7 @@ transformed parameters {
 
 model {
   // priors
-  init_R ~ normal(-0.1, 0.5); // Approximately Normal(1, 0.5)
+  init_R ~ normal(1, 0.5);
   rw_noise ~ std_normal();
   rw_sd ~ normal(0, 0.01) T[0,];
   damp ~ normal(1, 0.05) T[0, 1];

--- a/sessions/R-estimation-and-the-renewal-equation.qmd
+++ b/sessions/R-estimation-and-the-renewal-equation.qmd
@@ -259,14 +259,14 @@ data <- list(
   ip_pmf = ip_pmf
 )
 r_inf_fit <- r_inf_mod$sample(
-  data = data, parallel_chains = 4, init = \() list(init_R = 0)
+  data = data, parallel_chains = 4, init = \() list(init_R = 1)
 )
 ```
 
 ::: {.callout-note}
 Generally one should start MCMC samplers with multiple different starting values to make sure the whole posterior distribution is explored.
 When testing this model we noticed that sometimes the model failed to fit the data at all.
-Because of this we added an argument to start sampling with `init_R` set to 0.
+Because of this we added an argument to start sampling with `init_R` set to 1.
 This makes sure the sampler starts fitting the model from a sensible value and avoids fitting failiures.
 :::
 
@@ -383,7 +383,7 @@ data <- list(
 )
 r_rw_inf_fit <- rw_mod$sample(
   data = data, parallel_chains = 4, max_treedepth = 12, 
-  init = \() list(init_R = 0, rw_sd = 0.01)
+  init = \() list(init_R = 1, rw_sd = 0.01)
 )
 ```
 

--- a/sessions/forecast-visualisation.qmd
+++ b/sessions/forecast-visualisation.qmd
@@ -135,7 +135,7 @@ data <- list(
 )
 rw_forecast <- mod$sample(
   data = data, parallel_chains = 4, adapt_delta = 0.95,
-  init = \() list(init_R = 0, rw_sd = 0.01)
+  init = \() list(init_R = 1, rw_sd = 0.01)
 )
 ```
 
@@ -260,7 +260,7 @@ long_data <- list(
 
 rw_long <- mod$sample(
   data = long_data, parallel_chains = 4, adapt_delta = 0.95,
-  init = \() list(init_R = 0, rw_sd = 0.01)
+  init = \() list(init_R = 1, rw_sd = 0.01)
 )
 ```
 

--- a/sessions/forecasting-models.qmd
+++ b/sessions/forecasting-models.qmd
@@ -68,8 +68,8 @@ options(cmdstanr_print_line_numbers = TRUE)
 ## What did a geometric random walk model look like again?
 
 ```{r geometric-random-walk-sim}
-R <- geometric_random_walk(init = 1, noise = rnorm(100), std = 0.1)
-data <- tibble(t = seq_along(R), R = exp(R))
+R <- geometric_random_walk(init = 0, noise = rnorm(100), std = 0.1)
+data <- tibble(t = seq_along(R), R = R)
 
 ggplot(data, aes(x = t, y = R)) +
   geom_line() +
@@ -215,9 +215,9 @@ geometric_diff_ar
 We can use this function to simulate a differenced AR process:
 
 ```{r}
-log_R <- geometric_diff_ar(init = 1, noise = rnorm(100), std = 0.1, damp = 0.1)
+R <- geometric_diff_ar(init = 0, noise = rnorm(100), std = 0.1, damp = 0.1)
 
-data <- tibble(t = seq_along(log_R), R = exp(log_R))
+data <- tibble(t = seq_along(R), R = R)
 
 ggplot(data, aes(x = t, y = R)) +
   geom_line() +
@@ -296,7 +296,7 @@ data <- list(
 stat_forecast_fit <- stat_mod$sample(
   data = data, parallel_chains = 4,
   # again set the initial values to make fitting more numerically stable
-  init = \() list(init_R = 0, rw_sd = 0.01)
+  init = \() list(init_R = 1, rw_sd = 0.01)
 )
 ```
 


### PR DESCRIPTION
closes #324 
closes #321 

now consistently arguments passed to and returned by functions are on the natural scale

The only difference of substance to before is in the prior distributions for R -  from checking this does not lead to any problems. However it did unearth a typo in the script for generating forecasts. With profound apologies I am including a fix in the PR in spite of being unrelated to its core mission.