### PR TITLE
Fix #405: Add references to primarycensored and epidist packages in learning more sections

### DIFF
--- a/sessions/biases-in-delay-distributions.qmd
+++ b/sessions/biases-in-delay-distributions.qmd
@@ -332,5 +332,7 @@ Can you establish under which conditions the bias in estimation gets worse?
 -   The [`primarycensored`](https://github.com/epinowcast/primarycensored) R package provides a comprehensive framework for dealing with censored and truncated delay distributions.
     It implements many of the advanced techniques for handling primary event censoring, secondary event censoring, and right truncation in a unified and efficient manner.
     This package can be particularly useful for production-level implementations where performance and accuracy are critical.
+-   The [`epidist`](https://github.com/epinowcast/epidist) package extends `primarycensored` to work with `brms` for estimating epidemiological delay distributions.
+    It enables flexible modelling including time-varying components, spatial effects, and partially pooled estimates of demographic characteristics.
 
 # Wrap up

--- a/sessions/biases-in-delay-distributions.qmd
+++ b/sessions/biases-in-delay-distributions.qmd
@@ -330,7 +330,7 @@ Can you establish under which conditions the bias in estimation gets worse?
 -   We have looked at censoring and truncation separately, but in reality often both are present. Can you combine the two in a model?
 -   The solutions we introduced for addressing censoring and truncation are only some possible ones for the censoring problem. There are other solutions that reduce the biases from estimation even further. For a full overview, the [review by Park et al.](https://doi.org/10.1101/2024.01.12.24301247) might be worth a read. If you are feeling adventurous, try to implement one or more of them in the stan model above - with a warning that this can get quite involved very quickly.
 -   The [`primarycensored`](https://github.com/epinowcast/primarycensored) R package provides a comprehensive framework for dealing with censored and truncated delay distributions.
-    It implements many of the advanced techniques for handling primary event censoring, secondary event censoring, and right truncation in a unified and efficient manner.
+    It implements many techniques for handling primary event censoring, secondary event censoring, and right truncation in a unified and efficient manner.
     This package can be particularly useful for production-level implementations where performance and accuracy are critical.
 -   The [`epidist`](https://github.com/epinowcast/epidist) package extends `primarycensored` to work with `brms` for estimating epidemiological delay distributions.
     It enables flexible modelling including time-varying components, spatial effects, and partially pooled estimates of demographic characteristics.

--- a/sessions/biases-in-delay-distributions.qmd
+++ b/sessions/biases-in-delay-distributions.qmd
@@ -329,5 +329,8 @@ Can you establish under which conditions the bias in estimation gets worse?
 
 -   We have looked at censoring and truncation separately, but in reality often both are present. Can you combine the two in a model?
 -   The solutions we introduced for addressing censoring and truncation are only some possible ones for the censoring problem. There are other solutions that reduce the biases from estimation even further. For a full overview, the [review by Park et al.](https://doi.org/10.1101/2024.01.12.24301247) might be worth a read. If you are feeling adventurous, try to implement one or more of them in the stan model above - with a warning that this can get quite involved very quickly.
+-   The [`primarycensored`](https://github.com/epinowcast/primarycensored) R package provides a comprehensive framework for dealing with censored and truncated delay distributions.
+    It implements many of the advanced techniques for handling primary event censoring, secondary event censoring, and right truncation in a unified and efficient manner.
+    This package can be particularly useful for production-level implementations where performance and accuracy are critical.
 
 # Wrap up

--- a/sessions/using-delay-distributions-to-model-the-data-generating-process-of-an-epidemic.qmd
+++ b/sessions/using-delay-distributions-to-model-the-data-generating-process-of-an-epidemic.qmd
@@ -315,7 +315,7 @@ This is particularly useful when dealing with arrays such as `inference` because
     How would this look in stan code?
     Would you expect it to yield a different result?
 
--   The [`primarycensored`](https://github.com/epinowcast/primarycensored) package provides advanced tools for efficiently working with censored and truncated delay distributions.
+-   The [`primarycensored`](https://github.com/epinowcast/primarycensored) package provides tools for efficiently working with censored and truncated delay distributions.
     It offers both theoretical background on primary and secondary interval censoring and right truncation, as well as practical functions for estimating and using these distributions.
     The package implements deterministic methods that are significantly faster than the Monte Carlo approach used in `censored_delay_pmf()` while providing exact results.
 

--- a/sessions/using-delay-distributions-to-model-the-data-generating-process-of-an-epidemic.qmd
+++ b/sessions/using-delay-distributions-to-model-the-data-generating-process-of-an-epidemic.qmd
@@ -315,4 +315,8 @@ This is particularly useful when dealing with arrays such as `inference` because
     How would this look in stan code?
     Would you expect it to yield a different result?
 
+-   The [`primarycensored`](https://github.com/epinowcast/primarycensored) package provides advanced tools for efficiently working with censored and truncated delay distributions.
+    It offers both theoretical background on primary and secondary interval censoring and right truncation, as well as practical functions for estimating and using these distributions.
+    The package implements deterministic methods that are significantly faster than the Monte Carlo approach used in `censored_delay_pmf()` while providing exact results.
+
 # Wrap up


### PR DESCRIPTION
## Summary

- Adds references to the `primarycensored` and `epidist` packages in the "Going further" sections of key sessions
- Provides learners with information about more advanced tools for handling censored and truncated delay distributions
- Maintains the existing educational Monte Carlo approach while pointing to production-ready alternatives

## Changes

This PR adds information about advanced delay distribution packages to:
1. `sessions/using-delay-distributions-to-model-the-data-generating-process-of-an-epidemic.qmd` - Added a bullet point explaining that `primarycensored` provides efficient tools for working with censored and truncated delay distributions
2. `sessions/biases-in-delay-distributions.qmd` - Added two bullet points:
   - `primarycensored` as a comprehensive framework for production-level implementations
   - `epidist` which extends primarycensored to work with brms for flexible modeling including time-varying and spatial components

## Rationale

As discussed in #405, while replacing `censored_delay_pmf()` with `primarycensored` would provide significant performance benefits (200-500x speedup), it would remove the educational value of the Monte Carlo simulation approach. This PR takes a middle ground by:
- Keeping the existing educational implementation
- Directing interested learners to more advanced tools
- Providing a progression from basic (primarycensored) to advanced (epidist) tools
- Closing the issue without major code changes

## Test plan

- [x] Verified that the added content renders correctly in the course materials
- [x] Links to primarycensored and epidist GitHub repositories are functional
- [x] No changes to existing functionality

Closes #405

🤖 Generated with [Claude Code](https://claude.ai/code)