### PR TITLE
Replace vapply with for loop in convolve_with_delay for clarity

### DIFF
--- a/R/convolve-with-delay.r
+++ b/R/convolve-with-delay.r
@@ -16,7 +16,9 @@
 #' convolve_with_delay(ts = c(10, 14, 10, 10), delay_pmf = c(0.1, 0.6, 0.3))
 convolve_with_delay <- function(ts, delay_pmf) {
   max_delay <- length(delay_pmf) - 1 ## subtract one because zero-indexed
-  convolved <- vapply(seq_along(ts), \(i) {
+  convolved <- numeric(length(ts))
+
+  for (i in seq_along(ts)) {
     ## get vector of infections over the possible window of the delay period
     first_index <- max(1, i - max_delay)
     ts_segment <- ts[seq(first_index, i)]
@@ -24,7 +26,8 @@ convolve_with_delay <- function(ts, delay_pmf) {
     pmf <- rev(delay_pmf)[seq_len(i - first_index + 1)]
     ## convolve with delay distribution
     ret <- sum(ts_segment * pmf)
-    return(ret)
-  }, numeric(1))
-  return(convolved)
+    convolved[i] <- ret
+  }
+
+  convolved
 }


### PR DESCRIPTION
## Summary
- Refactored `convolve_with_delay` function to use an explicit for loop instead of `vapply`
- Pre-allocated result vector with `numeric(length(ts))` for better clarity of intent
- Maintained identical functionality and logic
- Fixed trailing whitespace issue

## Changes
- Replaced `vapply` with traditional for loop structure
- Added explicit vector pre-allocation
- Improved code readability while preserving all existing behaviour

## Test plan
- [x] Function maintains identical output for existing test cases
- [x] No changes to function interface or behaviour
- [x] Linting issues resolved

Fixes #297

🤖 Generated with [Claude Code](https://claude.ai/code)