### PR TITLE
Fix #437: Add merge group triggers to GitHub Actions workflows

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -5,6 +5,7 @@ on:
     branches: [main, master]
   pull_request:
     branches: [main, master]
+  merge_group:
 
 name: R-CMD-check
 

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -5,6 +5,7 @@ on:
     branches: [main, master]
   pull_request:
     branches: [main, master]
+  merge_group:
 
 jobs:
   lint:

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -5,6 +5,7 @@ on:
     branches: [main, master]
   pull_request:
     branches: [main, master]
+  merge_group:
 
 jobs:
   test-coverage:


### PR DESCRIPTION
## Summary

Adds `merge_group:` triggers to three GitHub Actions workflows that were missing them:
- R-CMD-check.yaml
- lint.yaml  
- test-coverage.yaml

## Problem

When PRs are queued for merging using GitHub's merge queue feature, these essential workflows were not running because they lacked `merge_group` triggers. This caused PRs to sit indefinitely in the merge queue since the required status checks were never executed.

## Solution

Added `merge_group:` triggers to the three workflows that were missing them, following the same pattern already established in `deploy.yaml`.

## Changes

- ✅ R-CMD-check.yaml: Added merge_group trigger
- ✅ lint.yaml: Added merge_group trigger  
- ✅ test-coverage.yaml: Added merge_group trigger
- ✅ deploy.yaml: Already had merge_group trigger
- ✅ render-readme.yaml: No change needed (only runs on main branch)

## Testing

- Verified YAML syntax is valid
- Confirmed consistent formatting with existing deploy.yaml workflow
- Changes follow GitHub Actions best practices for merge queue integration

Fixes #437

🤖 Generated with [Claude Code](https://claude.ai/code)