### PR TITLE
Fix #313: Add forecasting paradigm to forecast evaluation session

### DIFF
--- a/sessions/forecast-evaluation.qmd
+++ b/sessions/forecast-evaluation.qmd
@@ -65,6 +65,13 @@ An important aspect of making forecasts is that we can later confront the foreca
 2. **Unbiasedness**: The forecast should be unbiased. This means that the average forecasted value should be equal to the average observed value. It shouldn't consistently over- or underpredict.
 3. **Accuracy**: The forecast should be accurate. This means that the forecasted values should be close to the observed values.
 4. **Sharpness**: As long as the other conditions are fulfilled we want prediction intervals to be as narrow as possible. Predicting that "anything can happen" might be correct but not very useful.
+
+Note that sharpness is a property of the forecasts themselves, whereas calibration, unbiasedness, and accuracy are properties that emerge from comparing forecasts to observed data.
+
+## The forecasting paradigm
+
+The general principle underlying forecast evaluation is to **maximise *sharpness* subject to *calibration***.
+This means that statements about the future should be **correct** (calibration) and should aim to have **narrow uncertainty** (sharpness).
 :::
 
 


### PR DESCRIPTION
## Summary

This PR addresses issue #313 by adding the forecasting paradigm to the forecast evaluation session.

## Changes Made

- Added the forecasting paradigm ("maximise *sharpness* subject to *calibration*") to the callout tip in the forecast evaluation session
- Clarified that sharpness is a property of forecasts themselves, whereas calibration, unbiasedness, and accuracy result from comparing forecasts to observed data
- Enhanced the educational content by bringing the paradigm from slides into the main session content

## Context

Upon investigation, the forecasting paradigm was already present in the associated slides (`sessions/slides/forecast-evaluation.qmd`). However, for completeness and better accessibility for students, we've added it directly to the main session content as well.

## Testing

- Verified content follows UK English conventions as per project guidelines
- Ensured one-sentence-per-line markdown formatting
- Content integrates naturally with existing callout tip structure

🤖 Generated with [Claude Code](https://claude.ai/code)