### PR TITLE
Fix #486: Improve getting started documentation for installation issues

### DIFF
--- a/getting-started.qmd
+++ b/getting-started.qmd
@@ -4,7 +4,8 @@ title: "Getting started"
 
 ## What is NFIDD?
 
-NFIDD (Nowcasting and Forecasting Infectious Disease Dynamics) is an MIT-licensed library of [sessions](course-info/sessions) for learning about nowcasting and forecasting of infectious disease surveillance data. This course is a living resource designed to help epidemiologists, public health professionals, and researchers understand and apply real-time analysis methods to infectious disease surveillance data.
+NFIDD (Nowcasting and Forecasting Infectious Disease Dynamics) is an MIT-licensed library of [sessions](course-info/sessions) for learning about nowcasting and forecasting of infectious disease surveillance data.
+This course is a living resource designed to help epidemiologists, public health professionals, and researchers understand and apply real-time analysis methods to infectious disease surveillance data.
 
 ## Set up
 
@@ -33,8 +34,12 @@ If you choose the local setup option, here's what you'll need to do:
 
 ### Installing R
 
--   [R](http://cran.r-project.org) is used as the main programming language. You can check which version you have by typing `R.version` in your R session. We recommend installing the latest `r R.version$version.string`.
--   [RStudio](http://www.rstudio.com/products/rstudio/download/) is a popular graphic user interface (GUI). Its Visual Editor provides the best experience of going through this course. Please make sure you update RStudio to the latest version.
+-   [R](http://cran.r-project.org) is used as the main programming language.
+	You can check which version you have by typing `R.version` in your R session.
+	We recommend installing the latest `r R.version$version.string`.
+-   [RStudio](http://www.rstudio.com/products/rstudio/download/) is a popular graphic user interface (GUI). 
+	Its Visual Editor provides the best experience of going through this course. 
+	Please make sure you update RStudio to the latest version.
 
 ### Installing additional requirements
 
@@ -73,7 +78,7 @@ cmdstanr::install_cmdstan()
 ```
 
 ::: callout-note
-This may take a few minutes. 
+This may take a few minutes.
 Also you're likely to see lots of warnings and other messages printed to your screen - don't worry, this is normal and doesn't mean there is a problem.
 :::
 
@@ -103,7 +108,8 @@ If you want to use the local workflow, you will need a local copy of the course 
 
 -   Alternatively, if you are familiar with git you can clone the [repo](https://github.com/nfidd/nfidd).
 
--   If you prefer to use the hybrid workflow, you can view each session on the website, and copy-paste the code into your own R script. In that case you don't need to download the material.
+-   If you prefer to use the hybrid workflow, you can view each session on the website, and copy-paste the code into your own R script. 
+	In that case you don't need to download the material.
 
     -   Tip: if you hover over each code chunk on the website you can use a "Copy" button at the top right corner.
 
@@ -111,7 +117,9 @@ If you want to use the local workflow, you will need a local copy of the course 
 
 A benefit of downloading or cloning all the material is that you can interact with the session files directly.
 
-In this course, all content is written using [Quarto](https://quarto.org) notebooks (`.qmd` files). This means that we can combine text with code and see the output directly. The notebooks are then directly reproduced on the course website (for example, this page).
+In this course, all content is written using [Quarto](https://quarto.org) notebooks (`.qmd` files).
+This means that we can combine text with code and see the output directly. 
+The notebooks are then directly reproduced on the course website (for example, this page).
 
 **Recommended approach**: Work with the notebooks using RStudio's visual editor mode. See guidance on this below.
 

--- a/getting-started.qmd
+++ b/getting-started.qmd
@@ -73,7 +73,8 @@ cmdstanr::install_cmdstan()
 ```
 
 ::: callout-note
-This may take a few minutes. Also you're likely to see lots of warnings and other messages printed to your screen - don't worry, this is normal and doesn't mean there is a problem.
+This may take a few minutes. 
+Also you're likely to see lots of warnings and other messages printed to your screen - don't worry, this is normal and doesn't mean there is a problem.
 :::
 
 If there are any problems with this, you can try (on Windows) to fix them using
@@ -112,7 +113,7 @@ A benefit of downloading or cloning all the material is that you can interact wi
 
 In this course, all content is written using [Quarto](https://quarto.org) notebooks (`.qmd` files). This means that we can combine text with code and see the output directly. The notebooks are then directly reproduced on the course website (for example, this page).
 
-**Recommended approach**: Open the RStudio Project file (`nfidd.RProj`) in the `nfidd` folder you have downloaded and work directly with the notebook files.
+**Recommended approach**: Work with the notebooks using RStudio's visual editor mode. See guidance on this below.
 
 ::: callout-tip
 ## Using RStudio's Visual Editor (Recommended for Notebooks)
@@ -121,8 +122,6 @@ In this course, all content is written using [Quarto](https://quarto.org) notebo
 2.  **Switch to Visual mode**: Look for the "Visual" button in the top-left of the editor pane (next to "Source")
 3.  **Execute code**: Use the green "play" button at the top-right corner of each code chunk, or `Ctrl/Cmd + Enter` for line-by-line execution
 4.  **Visual mode benefits**: Easier to read formatted text and equations, better experience with code chunks and outputs
-
-**Note**: If you can't find the Visual button, make sure you're using RStudio 2022.07 or later.
 :::
 
 **Alternative approaches that also work**:
@@ -131,6 +130,7 @@ In this course, all content is written using [Quarto](https://quarto.org) notebo
 
 ::: callout-tip
 The Quarto extension for VS Code also supports a visual editor mode.
+You can find it in the command palette.
 :::
 
 ## Day-of-Course Updates

--- a/getting-started.qmd
+++ b/getting-started.qmd
@@ -71,7 +71,8 @@ library("nfidd")
 
 ### Installing `cmdstan`
 
-The course relies on running stan through the `cmdstanr` **R** package, which itself uses the `cmdstan` software. This requires a separate installation step:
+The course relies on running stan through the `cmdstanr` **R** package, which itself uses the `cmdstan` software.
+This requires a separate installation step:
 
 ```{r cmdstan_install, eval = FALSE}
 cmdstanr::install_cmdstan()

--- a/getting-started.qmd
+++ b/getting-started.qmd
@@ -11,7 +11,27 @@ This course is a living resource designed to help epidemiologists, public health
 
 Each session in this course uses R code for demonstration.
 All the content is self-contained within a software package designed for the course.
-To get the most out of this course, you will need to use R and the following instructions to interact with the course material.
+
+**You have three options for using this course:**
+
+1. **Web-only**: View sessions on the website
+2. **Local setup**: Install R, packages, and download course materials for the full interactive experience
+3. **Hybrid**: Install just the R package but use the website for viewing content
+
+::: callout-important
+**Installation Issues?** If you're having trouble with any installation steps, **ask for help early**! Don't skip ahead - each step builds on the previous ones. On the day of the course, we have a small number of web clients available as backup if installation issues persist.
+:::
+
+### Summary of Installation Steps
+
+If you choose the local setup option, here's what you'll need to do:
+
+1. Install R and RStudio (use the Visual Editor for best notebook experience)
+2. Install the `nfidd` R package
+3. Install cmdstan
+4. Download course materials (if using the hybrid approach you may not need to do this)
+
+**Don't skip any steps** - they all work together to provide the full course experience.
 
 ### Installing R
 
@@ -32,6 +52,15 @@ To install the packages needed in the course, including the `nfidd` package that
 install.packages("pak")
 pak::pak("nfidd/nfidd", dependencies = "all", upgrade = TRUE)
 ```
+
+::: callout-tip
+**If pak installation fails**, you can use this fallback method:
+
+```{r install_fallback, eval=FALSE}
+install.packages("remotes")
+remotes::install_github("nfidd/nfidd", dependencies = TRUE, upgrade = "always")
+```
+:::
 
 Then you can check that the installation completed successfully by loading the package into your **R** session:
 
@@ -86,17 +115,48 @@ To be able to use the code in each session, you will need a local copy of the co
 
 A benefit of downloading or cloning all the material is that you can interact with the session files directly.
 
-In this course, all content is written using [R Notebooks](https://bookdown.org/yihui/rmarkdown/notebook.html).
+In this course, all content is written using [Quarto](https://quarto.org) notebooks (`.qmd` files).
 This means that we can combine text with code and see the output directly.
 The notebooks are then directly reproduced on the course website (for example, this page).
 
-To interact with each session in the course, we recommend opening the RStudio Project file (`nfidd.RProj`) in the `nfidd` folder you have just downloaded.
-Then you can choose to:
+**Recommended approach**: Open the RStudio Project file (`nfidd.RProj`) in the `nfidd` folder you have downloaded and work directly with the notebook files.
 
--   View each session on the website, and copy-paste the code into your own R script.
-    -   Tip: if you hover over each code chunk on the website you can use a "Copy" button at the top right corner.
--   Open the R Notebook for each session.
-    -   Each notebook is saved in `nfidd/sessions/` as a `.qmd` file.
-    -   Execute code with the single green "play" button at the top-right corner of each code chunk ("Run current chunk"). You can also execute code line-by-line using `Ctrl/Cmd + Enter`.
-    -   We suggest using "Visual" view for a better experience (top-left of the RStudio pane).
+::: callout-tip
+## Using RStudio's Visual Editor (Recommended for Notebooks)
+
+1. **Open a session notebook**: Each session is saved as a `.qmd` file in `nfidd/sessions/`
+2. **Switch to Visual mode**: Look for the "Visual" button in the top-left of the editor pane (next to "Source")
+3. **Execute code**: Use the green "play" button at the top-right corner of each code chunk, or `Ctrl/Cmd + Enter` for line-by-line execution
+4. **Visual mode benefits**: Easier to read formatted text and equations, better experience with code chunks and outputs
+
+**Note**: If you can't find the Visual button, make sure you're using RStudio 2022.07 or later.
+:::
+
+**Alternative approaches that also work**:
+-   **Website + R script**: View each session on the website and copy-paste code into your own R script
+    -   Tip: Hover over code chunks on the website to see a "Copy" button in the top-right corner
+-   **Other editors**: Use VS Code or other editors that support Quarto notebooks - the `.qmd` files will work in any Quarto-compatible environment
+    - Tip: The Quarto extension for VS Code also supports a visual editor mode.
+
+## Day-of-Course Updates
+
+If you're returning to the course after some time or joining a live session, you may want to update your setup to ensure you have the latest content and package versions.
+
+### Quick Update (Recommended)
+
+1. **Update the nfidd package** (this is quick and ensures you have the latest functions):
+   ```{r update_package, eval=FALSE}
+   pak::pak("nfidd/nfidd", dependencies = "all", upgrade = TRUE)
+   ```
+   
+   Or using the fallback method if needed:
+   ```{r update_package_fallback, eval=FALSE}
+   remotes::install_github("nfidd/nfidd", dependencies = TRUE, upgrade = "always")
+   ```
+
+2. **Download fresh course materials** if using local files:
+   - Download the latest version: [[**Download**]{.underline}](https://github.com/nfidd/nfidd/archive/refs/heads/main.zip)
+   - Or use `git pull` if you cloned the repository
+
+3. **You don't need to reinstall cmdstan** unless you're having specific issues with it
 

--- a/getting-started.qmd
+++ b/getting-started.qmd
@@ -4,19 +4,17 @@ title: "Getting started"
 
 ## What is NFIDD?
 
-NFIDD (Nowcasting and Forecasting Infectious Disease Dynamics) is an MIT-licensed library of [sessions](course-info/sessions) for learning about nowcasting and forecasting of infectious disease surveillance data.
-This course is a living resource designed to help epidemiologists, public health professionals, and researchers understand and apply real-time analysis methods to infectious disease surveillance data.
+NFIDD (Nowcasting and Forecasting Infectious Disease Dynamics) is an MIT-licensed library of [sessions](course-info/sessions) for learning about nowcasting and forecasting of infectious disease surveillance data. This course is a living resource designed to help epidemiologists, public health professionals, and researchers understand and apply real-time analysis methods to infectious disease surveillance data.
 
 ## Set up
 
-Each session in this course uses R code for demonstration.
-All the content is self-contained within a software package designed for the course.
+Each session in this course uses R code for demonstration. All the content is self-contained within a software package designed for the course.
 
 **You have three options for using this course:**
 
-1. **Web-only**: View sessions on the website
-2. **Local setup**: Install R, packages, and download course materials for the full interactive experience
-3. **Hybrid**: Install just the R package but use the website for viewing content
+1.  **Web-only**: View sessions on the website
+2.  **Local setup**: Install R, packages, and download course materials for the full interactive experience
+3.  **Hybrid**: Install just the packages but use the website for viewing content
 
 ::: callout-important
 **Installation Issues?** If you're having trouble with any installation steps, **ask for help early**! Don't skip ahead - each step builds on the previous ones. On the day of the course, we have a small number of web clients available as backup if installation issues persist.
@@ -26,18 +24,16 @@ All the content is self-contained within a software package designed for the cou
 
 If you choose the local setup option, here's what you'll need to do:
 
-1. Install R and RStudio (use the Visual Editor for best notebook experience)
-2. Install the `nfidd` R package
-3. Install cmdstan
-4. Download course materials (if using the hybrid approach you may not need to do this)
+1.  Install R and RStudio (use the Visual Editor for best notebook experience)
+2.  Install the `nfidd` R package
+3.  Install cmdstan
+4.  Download course materials (if using the hybrid approach you may not need to do this)
 
 **Don't skip any steps** - they all work together to provide the full course experience.
 
 ### Installing R
 
--   [R](http://cran.r-project.org) is used as the main programming language.
-    You can check which version you have by typing `R.version` in your R session.
-    We recommend installing the latest `r R.version$version.string`.
+-   [R](http://cran.r-project.org) is used as the main programming language. You can check which version you have by typing `R.version` in your R session. We recommend installing the latest `r R.version$version.string`.
 -   [RStudio](http://www.rstudio.com/products/rstudio/download/) is a popular graphic user interface (GUI). Its Visual Editor provides the best experience of going through this course. Please make sure you update RStudio to the latest version.
 
 ### Installing additional requirements
@@ -70,16 +66,14 @@ library("nfidd")
 
 ### Installing `cmdstan`
 
-The course relies on running stan through the `cmdstanr` **R** package, which itself uses the `cmdstan` software.
-This requires a separate installation step:
+The course relies on running stan through the `cmdstanr` **R** package, which itself uses the `cmdstan` software. This requires a separate installation step:
 
 ```{r cmdstan_install, eval = FALSE}
 cmdstanr::install_cmdstan()
 ```
 
 ::: callout-note
-This may take a few minutes.
-Also you're likely to see lots of warnings and other messages printed to your screen - don't worry, this is normal and doesn't mean there is a problem.
+This may take a few minutes. Also you're likely to see lots of warnings and other messages printed to your screen - don't worry, this is normal and doesn't mean there is a problem.
 :::
 
 If there are any problems with this, you can try (on Windows) to fix them using
@@ -98,7 +92,7 @@ For more details, and for links to resources in case something goes wrong, see t
 
 ## Accessing the course
 
-To be able to use the code in each session, you will need a local copy of the course material.
+If you want to use the local workflow, you will need a local copy of the course material.
 
 -   Directly download the course material:
 
@@ -108,35 +102,36 @@ To be able to use the code in each session, you will need a local copy of the co
 
 -   Alternatively, if you are familiar with git you can clone the [repo](https://github.com/nfidd/nfidd).
 
--   If you prefer, you can also view each session on the website, and copy-paste the code into your own R script. In that case you don't need to download the material.
+-   If you prefer to use the hybrid workflow, you can view each session on the website, and copy-paste the code into your own R script. In that case you don't need to download the material.
+
     -   Tip: if you hover over each code chunk on the website you can use a "Copy" button at the top right corner.
 
 ### Interacting with a local copy of the course material
 
 A benefit of downloading or cloning all the material is that you can interact with the session files directly.
 
-In this course, all content is written using [Quarto](https://quarto.org) notebooks (`.qmd` files).
-This means that we can combine text with code and see the output directly.
-The notebooks are then directly reproduced on the course website (for example, this page).
+In this course, all content is written using [Quarto](https://quarto.org) notebooks (`.qmd` files). This means that we can combine text with code and see the output directly. The notebooks are then directly reproduced on the course website (for example, this page).
 
 **Recommended approach**: Open the RStudio Project file (`nfidd.RProj`) in the `nfidd` folder you have downloaded and work directly with the notebook files.
 
 ::: callout-tip
 ## Using RStudio's Visual Editor (Recommended for Notebooks)
 
-1. **Open a session notebook**: Each session is saved as a `.qmd` file in `nfidd/sessions/`
-2. **Switch to Visual mode**: Look for the "Visual" button in the top-left of the editor pane (next to "Source")
-3. **Execute code**: Use the green "play" button at the top-right corner of each code chunk, or `Ctrl/Cmd + Enter` for line-by-line execution
-4. **Visual mode benefits**: Easier to read formatted text and equations, better experience with code chunks and outputs
+1.  **Open a session notebook**: Each session is saved as a `.qmd` file in `nfidd/sessions/`
+2.  **Switch to Visual mode**: Look for the "Visual" button in the top-left of the editor pane (next to "Source")
+3.  **Execute code**: Use the green "play" button at the top-right corner of each code chunk, or `Ctrl/Cmd + Enter` for line-by-line execution
+4.  **Visual mode benefits**: Easier to read formatted text and equations, better experience with code chunks and outputs
 
 **Note**: If you can't find the Visual button, make sure you're using RStudio 2022.07 or later.
 :::
 
 **Alternative approaches that also work**:
--   **Website + R script**: View each session on the website and copy-paste code into your own R script
-    -   Tip: Hover over code chunks on the website to see a "Copy" button in the top-right corner
--   **Other editors**: Use VS Code or other editors that support Quarto notebooks - the `.qmd` files will work in any Quarto-compatible environment
-    - Tip: The Quarto extension for VS Code also supports a visual editor mode.
+
+**Other editors**: Use VS Code or other editors that support Quarto notebooks. The `.qmd` files will work in any Quarto-compatible environment.
+
+::: callout-tip
+The Quarto extension for VS Code also supports a visual editor mode.
+:::
 
 ## Day-of-Course Updates
 
@@ -144,19 +139,21 @@ If you're returning to the course after some time or joining a live session, you
 
 ### Quick Update (Recommended)
 
-1. **Update the nfidd package** (this is quick and ensures you have the latest functions):
-   ```{r update_package, eval=FALSE}
-   pak::pak("nfidd/nfidd", dependencies = "all", upgrade = TRUE)
-   ```
-   
-   Or using the fallback method if needed:
-   ```{r update_package_fallback, eval=FALSE}
-   remotes::install_github("nfidd/nfidd", dependencies = TRUE, upgrade = "always")
-   ```
+1.  **Update the nfidd package** (this is quick and ensures you have the latest functions):
 
-2. **Download fresh course materials** if using local files:
-   - Download the latest version: [[**Download**]{.underline}](https://github.com/nfidd/nfidd/archive/refs/heads/main.zip)
-   - Or use `git pull` if you cloned the repository
+    ```{r update_package, eval=FALSE}
+    pak::pak("nfidd/nfidd", dependencies = "all", upgrade = TRUE)
+    ```
 
-3. **You don't need to reinstall cmdstan** unless you're having specific issues with it
+    Or using the fallback method if needed:
 
+    ```{r update_package_fallback, eval=FALSE}
+    remotes::install_github("nfidd/nfidd", dependencies = TRUE, upgrade = "always")
+    ```
+
+2.  **Download fresh course materials** if using local files:
+
+    -   Download the latest version: [[**Download**]{.underline}](https://github.com/nfidd/nfidd/archive/refs/heads/main.zip)
+    -   Or use `git pull` if you cloned the repository
+
+3.  **You don't need to reinstall cmdstan** unless you're having specific issues with it


### PR DESCRIPTION
## Summary

This PR addresses installation issues and documentation gaps reported in #486 by improving the getting started documentation to better guide users through setup and provide clearer alternatives.

### Changes Made

- **Added pak installation fallback**: Users can now use `remotes::install_github()` if pak fails
- **Added installation summary**: Clear overview of all steps at the top prevents users from skipping critical steps  
- **Enhanced Visual Editor guidance**: Dedicated callout with step-by-step instructions for using RStudio's Visual Editor
- **Added day-of-course updates section**: Instructions for updating packages and materials without reinstalling cmdstan
- **Clarified usage options**: Three clear paths (web-only, local setup, hybrid) explained at the start
- **Added early help guidance**: Prominent callout encouraging users to ask for help early, mentioning web client backup

### Testing

- ✅ Quarto renders successfully without errors
- ✅ All installation code blocks are properly formatted
- ✅ Callouts display correctly
- ✅ Links work properly

### Addresses Issue Requirements

- [x] Pak installation fallback option
- [x] Clear installation steps summary 
- [x] Visual editor usage guidance
- [x] Day-of-course update instructions
- [x] Local vs web-only clarity
- [x] Early help-seeking encouragement

Fixes #486

🤖 Generated with [Claude Code](https://claude.ai/code)