### PR TITLE
fix links in course intro

### DIFF
--- a/sessions/introduction-and-course-overview.qmd
+++ b/sessions/introduction-and-course-overview.qmd
@@ -73,10 +73,10 @@ Broadly, the intended timeline is:
 
 Let's get started!
 
--   Have a more detailed look at the [learning objectives](/learning_objectives)
+-   Have a more detailed look at the [learning objectives](../reference/learning_objectives)
 
 -   [Introduction to the course and the instructors](slides/introduction-to-the-course-and-the-instructors)
 
--   If you haven't already, start with [getting set up for the course](/getting-set-up)
+-   If you haven't already, start with [getting set up for the course](../reference/getting-set-up)
 
--   Once you're all set up, let's introduce some concepts and methods we'll rely heavily in this course in the session on [probability distributions and parameter estimation](R-Stan-and-statistical-concepts.qmd).
+-   Once you're all set up, let's introduce some concepts and methods we'll rely heavily in this course in the session on [probability distributions and parameter estimation](probability-distributions-and-parameter-estimation).


### PR DESCRIPTION
haven't been able to test locally - seems like `quarto preview` doesn't add `.html` to links for some reason.