### PR TITLE
add feedback survey for asynchronous learners

### DIFF
--- a/sessions/end-of-course-summary-and-discussion.qmd
+++ b/sessions/end-of-course-summary-and-discussion.qmd
@@ -8,6 +8,7 @@ order: 13
 We hope that you've enjoyed taking this course on nowcasting and forecasting infectious disease dynamics.
 We will be very happy to have your feedback, comments or any questions on the [course discussion page](https://github.com/nfidd/nfidd/discussions).
 
+If you are exploring the course asynchronously, we'd be grateful to hear your experience. Please use this [survey](https://forms.gle/1LuhWJ2SNukgtUQM8) to let us know how you found the course.
 
 ## Slides
 


### PR DESCRIPTION
I wondered for a while about gathering feedback from people who are taking the course asychronously. Crossed my mind again as someone just got in touch to ask for the course materials. 

I set up a quick google [form](https://forms.gle/jKhiWtkvZn5drLLM8) that is a light edit on the existing feedback form that we sent around. I thought we could just drop a link to this in the end, in case anyone wants to use it.