### PR TITLE
Use quantile_level column for qra weights filter

### DIFF
--- a/sessions/forecast-ensembles.qmd
+++ b/sessions/forecast-ensembles.qmd
@@ -629,8 +629,8 @@ qra_weights <- seq_along(qra_ensembles_obj) |>
     mutate(origin_day = forecast_dates[i + 1])
   ) |>
   bind_rows() |>
-  dplyr::filter(quantile == 0.5) |>
-  select(-quantile)
+  dplyr::filter(quantile_level == 0.5) |>
+  select(-quantile_level)
 
 qra_ensembles <- qra_ensembles_obj |>
   bind_rows()


### PR DESCRIPTION
This PR closes #602.

`qrensemble`'s weights attribute now uses `quantile_level` instead of `quantile`, so the filter in the `[qra]` chunk of `sessions/forecast-ensembles.qmd` was failing the scheduled site deploy.

Verified against `qrensemble` 0.1.4: `attr(qra_result, "weights")` has columns `model`, `quantile_level`, `weight`.