### PR TITLE
Cite Bracher et al. 2021 for over/underprediction

### DIFF
--- a/sessions/forecast-ensembles.qmd
+++ b/sessions/forecast-ensembles.qmd
@@ -340,7 +340,7 @@ ensemble_scores <- simple_ensembles |>
 ```
 
 ::: {.callout-note}
-The **weighted interval score (WIS)** is a proper scoring rule for quantile forecasts that approximates the **Continuous Ranked Probability Score (CRPS)** by considering a weighted sum of multiple prediction intervals. As the number of intervals increases, the WIS converges to the CRPS, combining sharpness and penalties for over- and under-prediction.
+The **weighted interval score (WIS)** [@bracherEvaluatingEpidemicForecasts2021] is a proper scoring rule for quantile forecasts that approximates the **Continuous Ranked Probability Score (CRPS)** by considering a weighted sum of multiple prediction intervals. As the number of intervals increases, the WIS converges to the CRPS, combining sharpness and penalties for over- and under-prediction.
 
 We see it here as we are scoring quantiles and not samples hence we cannot use CRPS as we did before.
 :::

--- a/sessions/forecast-evaluation.qmd
+++ b/sessions/forecast-evaluation.qmd
@@ -64,7 +64,7 @@ An important aspect of making forecasts is that we can later confront the foreca
 1. **Calibration**: The forecast should be well calibrated. This means that the forecasted probabilities should match the observed frequencies. For example, if the model predicts a 50% probability of an event occurring, then the event should occur approximately 50% of the time.
 2. **Unbiasedness**: The forecast should be unbiased. This means that the average forecasted value should be equal to the average observed value. It shouldn't consistently over- or underpredict.
 3. **Accuracy**: The forecast should be accurate. This means that the forecasted values should be close to the observed values.
-4. **Sharpness**: As long as the other conditions are fulfilled we want prediction intervals to be as narrow as possible. Predicting that "anything can happen" might be correct but not very useful. The weighted interval score [@bracherEvaluatingEpidemicForecasts2021] decomposes the score for an interval forecast into sharpness, over-, and under-prediction components.
+4. **Sharpness**: As long as the other conditions are fulfilled we want prediction intervals to be as narrow as possible. Predicting that "anything can happen" might be correct but not very useful.
 
 Note that sharpness is a property of the forecasts themselves, whereas calibration, unbiasedness, and accuracy are properties that emerge from comparing forecasts to observed data.
 

--- a/sessions/forecast-evaluation.qmd
+++ b/sessions/forecast-evaluation.qmd
@@ -64,7 +64,7 @@ An important aspect of making forecasts is that we can later confront the foreca
 1. **Calibration**: The forecast should be well calibrated. This means that the forecasted probabilities should match the observed frequencies. For example, if the model predicts a 50% probability of an event occurring, then the event should occur approximately 50% of the time.
 2. **Unbiasedness**: The forecast should be unbiased. This means that the average forecasted value should be equal to the average observed value. It shouldn't consistently over- or underpredict.
 3. **Accuracy**: The forecast should be accurate. This means that the forecasted values should be close to the observed values.
-4. **Sharpness**: As long as the other conditions are fulfilled we want prediction intervals to be as narrow as possible. Predicting that "anything can happen" might be correct but not very useful.
+4. **Sharpness**: As long as the other conditions are fulfilled we want prediction intervals to be as narrow as possible. Predicting that "anything can happen" might be correct but not very useful. The weighted interval score [@bracherEvaluatingEpidemicForecasts2021] decomposes the score for an interval forecast into sharpness, over-, and under-prediction components.
 
 Note that sharpness is a property of the forecasts themselves, whereas calibration, unbiasedness, and accuracy are properties that emerge from comparing forecasts to observed data.
 
@@ -257,7 +257,7 @@ What does this tell you about the model?
 
 ### PIT histograms
 
-As well as the CRPS we can also look at the calibration and bias of the model. Calibration is the agreement between the forecast probabilities and the observed frequencies. Bias is a measure of how likely the model is to over or under predict the observed values [@bracherEvaluatingEpidemicForecasts2021].
+As well as the CRPS we can also look at the calibration and bias of the model [@funkAssessingPerformanceRealtime2019]. Calibration is the agreement between the forecast probabilities and the observed frequencies. Bias is a measure of how likely the model is to over or under predict the observed values.
 
 There are many ways to assess calibration and bias but one common way is to use a probability integral transform (PIT) histogram. This is a histogram of the cumulative distribution of function of a forecast evaluated at the observed value.
 

--- a/sessions/forecast-evaluation.qmd
+++ b/sessions/forecast-evaluation.qmd
@@ -257,7 +257,7 @@ What does this tell you about the model?
 
 ### PIT histograms
 
-As well as the CRPS we can also look at the calibration and bias of the model. Calibration is the agreement between the forecast probabilities and the observed frequencies. Bias is a measure of how likely the model is to over or under predict the observed values.
+As well as the CRPS we can also look at the calibration and bias of the model. Calibration is the agreement between the forecast probabilities and the observed frequencies. Bias is a measure of how likely the model is to over or under predict the observed values [@bracherEvaluatingEpidemicForecasts2021].
 
 There are many ways to assess calibration and bias but one common way is to use a probability integral transform (PIT) histogram. This is a histogram of the cumulative distribution of function of a forecast evaluated at the observed value.
 


### PR DESCRIPTION
This PR closes #371.

- Cites Bracher et al. 2021 (PLOS CB, *Evaluating Epidemic Forecasts in an Interval Format*) at the WIS explainer in `forecast-ensembles.qmd`, where over- and under-prediction are introduced as components of the score.
- Cites Funk et al. 2019 (PLOS CB, *Assessing the Performance of Real-Time Epidemic Forecasts*) at the calibration / bias paragraph in the PIT histograms section of `forecast-evaluation.qmd`.