### PR TITLE
Use N for sample size in lognormal.stan to match gamma.stan

### DIFF
--- a/inst/stan/lognormal.stan
+++ b/inst/stan/lognormal.stan
@@ -1,7 +1,7 @@
 // lognormal_model.stan
 data {
-  int<lower=0> n; // number of data points
-  array[n] real y; // data
+  int<lower=0> N; // number of data points
+  array[N] real y; // data
 }
 
 parameters {

--- a/sessions/biases-in-delay-distributions.qmd
+++ b/sessions/biases-in-delay-distributions.qmd
@@ -216,7 +216,7 @@ Do you still recover the parameters that we put in?
 mod <- nfidd_cmdstan_model("lognormal")
 res <- nfidd_sample(mod,
   data = list(
-    n = nrow(na.omit(df_dates)),
+    N = nrow(na.omit(df_dates)),
     y = na.omit(df_dates)$onset_to_hosp + 0.01
   )
 )
@@ -554,7 +554,7 @@ How far away from the "true" parameters do you end up?
 ```{r df_realtime_solution, results = 'hide', message = FALSE}
 res <- nfidd_sample(mod,
   data = list(
-    n = nrow(na.omit(df_realtime)),
+    N = nrow(na.omit(df_realtime)),
     y = na.omit(df_realtime)$onset_to_hosp
   )
 )

--- a/sessions/delay-distributions.qmd
+++ b/sessions/delay-distributions.qmd
@@ -236,7 +236,7 @@ df_onset_to_hosp <- df |>
 res <- nfidd_sample(
   mod,
   data = list(
-    n = nrow(df_onset_to_hosp),
+    N = nrow(df_onset_to_hosp),
     y = df_onset_to_hosp$onset_to_hosp
   )
 )


### PR DESCRIPTION
This PR closes #515.

In session 1 the gamma model uses uppercase `N` for the sample size, while `lognormal.stan` was using lowercase `n`. This meant the challenge to swap in the lognormal model didn't plug-and-play.

Renames `n` → `N` in:
- `inst/stan/lognormal.stan` (data block)
- `sessions/delay-distributions.qmd` (lognormal call)
- `sessions/biases-in-delay-distributions.qmd` (two lognormal calls; censored/truncated models keep `n` to match their own stan code)