### PR TITLE
Drop unused gen_time_pmf argument from simulate_onsets

### DIFF
--- a/R/simulate_onsets.r
+++ b/R/simulate_onsets.r
@@ -36,9 +36,6 @@ make_ip_pmf <- function(max = 14, shape = 5, rate = 1) {
 #' @param inf_ts A data frame containing columns infection_day and infections,
 #'   as returned by `make_daily_infections()`.
 #'
-#' @param gen_time_pmf A vector of probabilities representing the generation
-#'   time PMF, as returned by `make_gen_time_pmf()`.
-#'
 #' @param ip_pmf A vector of probabilities representing the incubation period
 #'   PMF, as returned by `make_ip_pmf()`.
 #'
@@ -53,11 +50,9 @@ make_ip_pmf <- function(max = 14, shape = 5, rate = 1) {
 #' @export
 #'
 #' @examples
-#' gt_pmf <- make_gen_time_pmf()
 #' ip_pmf <- make_ip_pmf()
-#' simulate_onsets(make_daily_infections(infection_times), gt_pmf, ip_pmf)
-simulate_onsets <- function(inf_ts, gen_time_pmf = make_gen_time_pmf(),
-                            ip_pmf = make_ip_pmf()) {
+#' simulate_onsets(make_daily_infections(infection_times), ip_pmf)
+simulate_onsets <- function(inf_ts, ip_pmf = make_ip_pmf()) {
   onsets <- convolve_with_delay(inf_ts$infections, ip_pmf)
   onsets <- rpois(n = length(onsets), lambda = onsets)
   onset_df <- tibble(day = seq_along(onsets), onsets = onsets) |>

--- a/man/simulate_onsets.Rd
+++ b/man/simulate_onsets.Rd
@@ -4,18 +4,11 @@
 \alias{simulate_onsets}
 \title{Simulate symptom onsets from daily infection counts}
 \usage{
-simulate_onsets(
-  inf_ts,
-  gen_time_pmf = make_gen_time_pmf(),
-  ip_pmf = make_ip_pmf()
-)
+simulate_onsets(inf_ts, ip_pmf = make_ip_pmf())
 }
 \arguments{
 \item{inf_ts}{A data frame containing columns infection_day and infections,
 as returned by `make_daily_infections()`.}
-
-\item{gen_time_pmf}{A vector of probabilities representing the generation
-time PMF, as returned by `make_gen_time_pmf()`.}
 
 \item{ip_pmf}{A vector of probabilities representing the incubation period
 PMF, as returned by `make_ip_pmf()`.}
@@ -28,7 +21,6 @@ A data frame with columns day, onsets, and infections containing
 Simulate symptom onsets from daily infection counts
 }
 \examples{
-gt_pmf <- make_gen_time_pmf()
 ip_pmf <- make_ip_pmf()
-simulate_onsets(make_daily_infections(infection_times), gt_pmf, ip_pmf)
+simulate_onsets(make_daily_infections(infection_times), ip_pmf)
 }

--- a/sessions/forecast-ensembles.qmd
+++ b/sessions/forecast-ensembles.qmd
@@ -115,7 +115,7 @@ Some important things to note about these forecasts:
 gen_time_pmf <- make_gen_time_pmf()
 ip_pmf <- make_ip_pmf()
 onset_df <- simulate_onsets(
-  make_daily_infections(infection_times), gen_time_pmf, ip_pmf
+  make_daily_infections(infection_times), ip_pmf
 )
 head(onset_df)
 ```

--- a/sessions/forecast-evaluation.qmd
+++ b/sessions/forecast-evaluation.qmd
@@ -101,7 +101,7 @@ Some important things to note about these forecasts:
 gen_time_pmf <- make_gen_time_pmf()
 ip_pmf <- make_ip_pmf()
 onset_df <- simulate_onsets(
-  make_daily_infections(infection_times), gen_time_pmf, ip_pmf
+  make_daily_infections(infection_times), ip_pmf
 )
 ```
 

--- a/sessions/forecasting-concepts.qmd
+++ b/sessions/forecasting-concepts.qmd
@@ -106,7 +106,7 @@ We will try to make a forecast on day 71 (assuming we don't know what the data l
 gen_time_pmf <- make_gen_time_pmf()
 ip_pmf <- make_ip_pmf()
 onset_df <- simulate_onsets(
-  make_daily_infections(infection_times), gen_time_pmf, ip_pmf
+  make_daily_infections(infection_times), ip_pmf
 )
 tail(onset_df)
 ## create hold out dataset

--- a/sessions/forecasting-models.qmd
+++ b/sessions/forecasting-models.qmd
@@ -246,7 +246,7 @@ We will now use the mechanistic and statistical models to forecast the number of
 gen_time_pmf <- make_gen_time_pmf()
 ip_pmf <- make_ip_pmf()
 onset_df <- simulate_onsets(
-  make_daily_infections(infection_times), gen_time_pmf, ip_pmf
+  make_daily_infections(infection_times), ip_pmf
 )
 onset_df
 

--- a/sessions/joint-nowcasting.qmd
+++ b/sessions/joint-nowcasting.qmd
@@ -88,7 +88,7 @@ First, let's generate our simulated onset dataset as before:
 gen_time_pmf <- make_gen_time_pmf()
 ip_pmf <- make_ip_pmf()
 onset_df <- simulate_onsets(
-  make_daily_infections(infection_times), gen_time_pmf, ip_pmf
+  make_daily_infections(infection_times), ip_pmf
 )
 head(onset_df)
 cutoff <- 71

--- a/sessions/nowcasting.qmd
+++ b/sessions/nowcasting.qmd
@@ -194,7 +194,7 @@ We can now use this delay distribution to nowcast the most recent data. Here we 
 gen_time_pmf <- make_gen_time_pmf()
 ip_pmf <- make_ip_pmf()
 onset_df <- simulate_onsets(
-  make_daily_infections(infection_times), gen_time_pmf, ip_pmf
+  make_daily_infections(infection_times), ip_pmf
 )
 reported_onset_df <- onset_df |>
   filter(day < cutoff) |>


### PR DESCRIPTION
This PR closes #528.

`simulate_onsets()` accepted a `gen_time_pmf` argument that was never used inside the function (only `ip_pmf` is needed to convolve infections to onsets). All six call sites in the session `.qmd` files passed it positionally; updated them to drop the unused argument while keeping the local `gen_time_pmf` assignment for the renewal models that follow.