### PR TITLE
Motivate use of simulated data in intro stats session

### DIFF
--- a/sessions/probability-distributions-and-parameter-estimation.qmd
+++ b/sessions/probability-distributions-and-parameter-estimation.qmd
@@ -58,6 +58,10 @@ options(cmdstanr_print_line_numbers = TRUE)
 
 # Simulating data from a probability distribution
 
+Throughout this course we use **simulated data** as our running examples.
+Working with simulation has two big teaching advantages: we always know the *true* parameter values, so we can check whether our inference recovers them; and we can isolate one part of the data-generating process at a time without confounding from real-world reporting noise.
+We will start by simulating from probability distributions; later sessions extend this to simulating delays, transmission, and reporting in turn, and then use the same probabilistic models to do inference on the data we have generated.
+
 First let us simulate some data from a probability distribution.
 In R, this is usually done using a family of random number generation functions that start with `r`.
 For example, to simulate random numbers from a normal distribution you would use the `rnorm()` function.


### PR DESCRIPTION
This PR closes #339.

The first part of the issue (epicurve in the intro slides) was already addressed in PR #587 — `slides/from-line-list-to-decisions.qmd` shows the simulated `infection_times` curve under the "Approach" slide.

This PR addresses the second part: a short paragraph at the top of the "Simulating data from a probability distribution" section in `probability-distributions-and-parameter-estimation.qmd`, motivating *why* the course uses simulated data (knowing the truth, isolating one part of the DGP at a time) and previewing how the simulation theme is built up across later sessions.