### PR TITLE
Update learning outcomes to match course content

### DIFF
--- a/reference/learning_objectives.qmd
+++ b/reference/learning_objectives.qmd
@@ -10,7 +10,9 @@ While examples often use outbreak scenarios for clarity, participants should con
 ## R and statistical concepts used
 
 - understanding of common probability distributions used for epidemiological delays
+- familiarity with the basics of Bayesian inference and MCMC sampling
 - familiarity with using stan to estimate parameters of a probability distribution
+- ability to interpret a posterior summary, including key convergence diagnostics
 
 ## Delay distributions
 
@@ -44,15 +46,30 @@ While examples often use outbreak scenarios for clarity, participants should con
 - awareness of the breadth of methods to perform nowcasting
 - $R_t$ estimation as a nowcasting problem
 
-## Forecasting
+## Joint nowcasting with an unknown reporting delay
+
+- understanding of the reporting triangle as a representation of partially-observed reporting data
+- ability to jointly estimate a reporting delay distribution and a nowcast in R
+- awareness of how nowcasting can be combined with $R_t$ estimation in a single model
+
+## Forecasting concepts
 
 - understanding of forecasting as an epidemiological problem, and its relationship with nowcasting and $R_t$ estimation
 - ability to use a forecasting model on an epidemiological time series in R
+- familiarity with the forecasting paradigm of maximising sharpness subject to calibration
+
+## Forecasting models
+
+- awareness of forecasting models as a spectrum from mechanistic to statistical
+- ability to extend a renewal-equation forecasting model with additional mechanistic structure (e.g. susceptible depletion)
+- ability to extend a forecasting model with additional statistical structure (e.g. autoregressive components)
 
 ## Evaluating forecasts (and nowcasts)
 
 - ability to visually assess forecasts and nowcasts
 - familiarity with metrics for evaluating probabilistic forecasts and their properties
+- understanding of proper scoring rules and the components of the weighted interval score (sharpness, over- and under-prediction)
+- ability to assess calibration and bias using PIT histograms
 - ability to score probabilistic forecasts in R
 - ability to compare different models by their forecast scores
 
@@ -60,4 +77,5 @@ While examples often use outbreak scenarios for clarity, participants should con
 
 - understanding of predictive ensembles and their properties
 - ability to create a predictive ensemble of forecasts in R
+- familiarity with weighted ensembles, including inverse-WIS weighting and quantile regression averaging
 


### PR DESCRIPTION
This PR closes #534.

Cross-checked each session against `reference/learning_objectives.qmd` and updated to reflect what is actually delivered.

Changes:
- **R / statistical concepts**: added Bayesian inference + MCMC and posterior interpretation outcomes (the session now contains the MCMC callout from #383).
- **Joint nowcasting with an unknown reporting delay**: new subsection — the whole `joint-nowcasting.qmd` session had no LO entry.
- **Forecasting** split into **Forecasting concepts** (paradigm added) and **Forecasting models** (mechanistic↔statistical spectrum, adding structure) to match the two distinct sessions.
- **Evaluating forecasts**: added WIS components and PIT histograms.
- **Ensemble models**: added weighted ensembles (inverse-WIS, QRA).

Existing wording for delays / biases / convolution / Rt sessions left unchanged — content matches well. Methods-in-real-world / examples-of-available-tools sessions treated as supplemental and not given separate LOs.