### PR TITLE
Use ASCII "naive" for consistency

### DIFF
--- a/sessions/biases-in-delay-distributions.qmd
+++ b/sessions/biases-in-delay-distributions.qmd
@@ -177,7 +177,7 @@ The concepts and techniques that we use here also apply to longer time intervals
 
 Let's estimate the time from symptom onset to hospitalisation with the censored data.
 
-A naïve approach to estimating the delay would be to ignore the fact that the data are censored.
+A naive approach to estimating the delay would be to ignore the fact that the data are censored.
 To estimate the delay from onset to hospitalisation, we could just use the difference between the censored times, which is an integer (the number of days).
 
 ```{r integer-delays}
@@ -532,7 +532,7 @@ Ending observation close to periods of exponential growth will lead to more trun
 
 ## Implementing bias correction for truncation
 
-If we take the naïve mean of delays we get an underestimate as expected:
+If we take the naive mean of delays we get an underestimate as expected:
 
 ```{r mean_truncated}
 # truncated mean delay


### PR DESCRIPTION
**This is entirely from an agent so do not review until I have pinged for review as I will do a first pass**

## Summary

A reviewer flagged seeing the odd fragment \"ke the naïve m\" while reading the course. This fragment came from the non-ASCII spelling \"naïve\" (ï = U+00EF) at line 535 of `sessions/biases-in-delay-distributions.qmd`. A second occurrence also existed at line 180 of the same file.

- Replaced both occurrences of non-ASCII \"naïve\" with plain ASCII \"naive\" in `sessions/biases-in-delay-distributions.qmd` (lines 180 and 535).
- This standardises spelling to match the rest of the repo (e.g. chunk labels `naive_delay_model`, `sessions/delay-distributions.qmd`), making it ASCII-clean and consistent.

> ⚠️ This PR was generated by an automated agent and may need human review before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code) # checks-passed