### PR TITLE
Fix broken Markdown lists in Stan reference

### DIFF
--- a/reference/stan.qmd
+++ b/reference/stan.qmd
@@ -167,8 +167,8 @@ prior_sd_delay <- abs(rnorm(1000, mean = 0.5, sd = 0.1))
 
 # Simulate delays from these priors
 prior_delays <- rlnorm(
-  1000, 
-  meanlog = log(prior_mean_delay), 
+  1000,
+  meanlog = log(prior_mean_delay),
   sdlog = prior_sd_delay
 )
 
@@ -223,9 +223,9 @@ Solutions:
 ```{r, eval = FALSE}
 # Increase adapt_delta (default is 0.8)
 fit <- nfidd_sample(
-  model, 
+  model,
   data = stan_data,
-  adapt_delta = 0.95  # or even 0.99 for difficult models
+  adapt_delta = 0.95 # or even 0.99 for difficult models
 )
 ```
 

--- a/reference/stan.qmd
+++ b/reference/stan.qmd
@@ -20,6 +20,7 @@ Stan is a probabilistic programming language for Bayesian inference. It allows u
 - Get proper uncertainty quantification for our estimates
 
 We use Stan because:
+
 - We'll need to estimate things (delays, reproduction numbers, case numbers now and in the future)
 - We'll want to correctly specify uncertainty
 - We'll want to incorporate our domain expertise
@@ -32,11 +33,13 @@ We use Stan because:
 A probability distribution describes how likely different outcomes are for a random variable.
 
 **Discrete distributions** (for countable outcomes):
+
 - Example: Number of horse kick deaths per year (0, 1, 2, 3, ...)
 - Poisson distribution with $\lambda$ = 0.61 kicks per year
 - Probability of exactly 2 deaths: `dpois(2, lambda = 0.61)` = 0.11
 
 **Continuous distributions** (for measurable quantities):
+
 - Example: Temperature in Stockholm tomorrow
 - Normal distribution with mean 23°C, standard deviation 2°C
 - Probability density at 30°C: `dnorm(30, mean = 23, sd = 2)` = 0.0001


### PR DESCRIPTION
**This is entirely from an agent so do not review until I have pinged for review as I will do a first pass**

## Summary

Several bullet lists in `reference/stan.qmd` were not rendering correctly because there was no blank line between the introducing colon-line and the first bullet. In Markdown/Quarto, this causes the bullets to be treated as continuation of the preceding paragraph rather than a new list.

Three lists were fixed by inserting a single blank line:

- **"We use Stan because:"** (around line 22) — followed by 4 bullets explaining the reasons for using Stan
- **"Discrete distributions (for countable outcomes):"** (around line 35) — followed by the Poisson/horse-kick example bullets
- **"Continuous distributions (for measurable quantities):"** (around line 41) — followed by the Normal/temperature example bullets

No wording was changed, and no other content was modified. Minor styler fixes (trailing whitespace in R code blocks, missing EOF newline) were also applied.

---

> [!NOTE]
> This PR was generated by an automated agent and may need human review before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)