### PR TITLE
Remove course-development history phrasing from session text

### DIFF
--- a/sessions/biases-in-delay-distributions.qmd
+++ b/sessions/biases-in-delay-distributions.qmd
@@ -74,7 +74,7 @@ For this session, we'll use **shorter delays** to better demonstrate censoring e
 Using shorter delays makes the 24-hour censoring interval more impactful relative to the delay length, making bias effects more visible.
 :::
 
-We'll use the updated `add_delays` function with shorter parameters for the censoring demonstration:
+We'll use the `add_delays` function with shorter parameters for the censoring demonstration:
 
 ```{r inf_hosp_solution}
 df <- add_delays(

--- a/sessions/delay-distributions.qmd
+++ b/sessions/delay-distributions.qmd
@@ -353,7 +353,7 @@ With real data, of course, we don't have this information available.
   df_small <- df_onset_to_hosp |> slice_sample(n = 100)
   ```
 
-- **Different delay lengths**: The updated `add_delays()` function now allows you to change the delay parameters. 
+- **Different delay lengths**: The `add_delays()` function allows you to change the delay parameters.
   
   Try longer delays and see how this affects your parameter recovery:
   ```{r, eval = FALSE}


### PR DESCRIPTION
The course text should describe the materials as they are now, not narrate how the course/package was developed. Two learner-facing lines used development-history phrasing:

- `sessions/delay-distributions.qmd`: "The updated `add_delays()` function now allows you to change the delay parameters." → "The `add_delays()` function allows you to change the delay parameters."
- `sessions/biases-in-delay-distributions.qmd`: "We'll use the updated `add_delays` function with shorter parameters" → "We'll use the `add_delays` function with shorter parameters"

> Generated by an agent; please review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)