### PR TITLE
Add optional dropdown on marginal vs conditional nowcasting methods

### DIFF
--- a/sessions/joint-nowcasting.qmd
+++ b/sessions/joint-nowcasting.qmd
@@ -480,6 +480,15 @@ Think about seasonal patterns, long-term trends, or other cyclical behaviours th
 - This session focused on the role of the generative process in nowcasting. This is an area of active research but [@lisonGenerativeBayesianModeling2024] gives a good overview of the current state of the art.
 - The [`epinowcast`](https://package.epinowcast.org/) package implements a more complex version of the model we have used here. It is designed to be highly flexible and so can be used to model a wide range of different datasets.
 
+::: {.callout-note collapse="true"}
+## Optional: Marginal vs conditional approaches to nowcasting
+
+[@stonerPowerfulModellingFramework2020] review the literature on correcting delayed reporting and group methods into two broad classes based on how they treat the reporting delay.
+*Conditional* approaches model the delayed counts conditional on the eventual total, alongside a separate model for that total - typically by decomposing the reporting process into the probabilities of reporting at each delay (for example via a multinomial or survival-style model of the reporting triangle). The joint model in this session is of this type: we model the expected onsets $\lambda_{t}$ and the delay probabilities $p_{t,d}$ separately and combine them.
+
+*Marginal* approaches instead model the counts in each delay cell more directly, capturing the delay structure through covariates and random effects rather than an explicit conditional delay distribution. Regression-based and chain-ladder-style models therefore sit within the marginal class. A practical trade-off is that, because marginal approaches do not explicitly model the total, they can be less well suited to propagating uncertainty into the nowcast of the eventual count.
+:::
+
 # Wrap up
 
 The learning objectives for this session were:


### PR DESCRIPTION
## Summary

Adds a short optional, collapsed callout to the **Methods in practice** section of `sessions/joint-nowcasting.qmd` (just before `# Wrap up`).

The dropdown:

- Cites the Stoner review (`[@stonerPowerfulModellingFramework2020]` — Stoner, Economou & Halliday, 2020, *A Powerful Modelling Framework for Nowcasting and Forecasting COVID-19 and Other Diseases*).
- Explains the distinction between **conditional** nowcasting approaches (model delay counts conditional on the eventual total alongside a separate model for the total — the generative, delay-distribution-based decomposition of the reporting triangle used in this session) and **marginal** approaches (model the delay-cell counts more directly, capturing delay structure via covariates/random effects).
- Notes that **regression-based / chain-ladder-style models sit within the marginal class**, with a brief note on the practical trade-off (marginal approaches do not explicitly model the total).

The framing was verified against the actual Stoner et al. (2020) paper (arXiv:1912.05965, Section 2.1), which states the methods can be "broadly classified in two groups: one where the delayed counts ... are modelled marginally without explicitly modelling/using historical information on the totals ... and another which models the delay counts ... conditionally on y ... in conjunction with a separate model for y." Regression/chain-ladder approaches (Bastos et al. 2019) are cited there as marginal.

Implemented as a `::: {.callout-note collapse="true"}` callout matching the repo's convention for optional dropdowns. The citation will render into the existing `::: {#refs}` bibliography (bib already wired via `bibliography: ../nfidd.bib`). No render output or `_freeze/` changes.

This PR was generated by an agent and may need human review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)