### PR TITLE
Plot the forecast reproduction number over the forecast horizon

### DIFF
--- a/inst/stan/estimate-inf-and-r-rw-forecast.stan
+++ b/inst/stan/estimate-inf-and-r-rw-forecast.stan
@@ -36,6 +36,7 @@ model {
 }
 generated quantities {
   array[h] real forecast;
+  array[h] real forecast_R;
   if (h > 0) {
     array[n + h - 1] real f_rw_noise;
     for (i in 1:(n-1)) {
@@ -49,6 +50,7 @@ generated quantities {
     array[h + n] real f_onsets = convolve_with_delay(f_infections, ip_pmf);
     for (i in 1:h) {
       forecast[i] = poisson_rng(f_onsets[n + i]);
+      forecast_R[i] = f_R[n + i];
     }
   }
 }

--- a/sessions/forecasting-concepts.qmd
+++ b/sessions/forecasting-concepts.qmd
@@ -274,8 +274,17 @@ We first need to extract the forecast and estimated reproduction numbers.
 ```{r extract-Rt}
 forecast_r <- rw_forecast |>
   gather_draws(R[day]) |>
-  ungroup() |> 
+  ungroup() |>
   mutate(type = "forecast")
+
+# The forecast model also produces reproduction numbers for the forecast
+# horizon (`forecast_R`), which we append so the forecast extends past the
+# cutoff. Its day index runs from 1, so we shift it to follow the fitted days.
+forecast_r <- rw_forecast |>
+  gather_draws(forecast_R[day]) |>
+  ungroup() |>
+  mutate(day = day + cutoff, type = "forecast") |>
+  bind_rows(forecast_r)
 
 long_r <- rw_long |>
   gather_draws(R[day]) |>


### PR DESCRIPTION
In the forecasting concepts session, the plot under "We can now plot the forecast and estimated reproduction numbers" did not show the forecast Rt extending past the cutoff.

**Cause:** the forecast model (`estimate-inf-and-r-rw-forecast.stan`) computes the reproduction number over the forecast horizon (`f_R`) in `generated quantities`, but only returned the forecast *onsets*. So `gather_draws(R[day])` on the forecast fit only covered days up to the cutoff, and the blue forecast Rt line stopped at the vertical dashed line.

**Fix:**
- Output `forecast_R` (the reproduction number over the forecast horizon) from the model.
- Append it to the forecast Rt trajectory in the `extract-Rt` chunk (shifted by `cutoff`) so the forecast extends across the horizon, matching the onset forecast plots.

Verified locally: the model compiles, and an end-to-end fit confirms `forecast_R` now spans the full 28-day horizon (days 72–99) with finite values. `_freeze/` is gitignored so CI renders fresh. The model is only used in this session.

> Generated by an agent; please review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)