### PR TITLE
Add optional dropdown on baselines to forecasting concepts

### DIFF
--- a/nfidd.bib
+++ b/nfidd.bib
@@ -440,6 +440,17 @@
   doi = {10.7554/eLife.81916}
 }
 
+@misc{stapperMindBaseline2025,
+  title = {Mind the Baseline: The Hidden Impact of Reference Model Selection on Forecast Assessment},
+  author = {Stapper, Manuel and Funk, Sebastian},
+  year = {2025},
+  month = aug,
+  pages = {2025.08.01.25332807},
+  publisher = {medRxiv},
+  doi = {10.1101/2025.08.01.25332807},
+  archiveprefix = {medRxiv}
+}
+
 @misc{stonerPowerfulModellingFramework2020,
   title = {A {{Powerful Modelling Framework}} for {{Nowcasting}} and {{Forecasting COVID-19}} and {{Other Diseases}}},
   author = {Stoner, Oliver and Economou, Theo and Halliday, Alba},

--- a/sessions/forecasting-concepts.qmd
+++ b/sessions/forecasting-concepts.qmd
@@ -409,6 +409,18 @@ Do they seem to under or over predict consistently?
 - @heldProbabilisticForecastingInfectious2017 makes a compelling argument for the use of probabilistic forecasts and evaluates spatial forecasts based on routine surveillance data.
 - @hadleyVisualPreferencesCommunicating2025 describes the visualisation of modelling results for national COVID-19 policy and decision makers, with recommendations on what aspects of visuals, graphs, and plots policymakers found to be most helpful in COVID-19 response work.
 
+::: {.callout-note collapse="true"}
+## Using this model as a baseline
+
+The random walk renewal model used here is deliberately simple, which makes it a natural *baseline*: a reference forecast that more sophisticated models should be expected to beat before we trust them.
+Comparing models against a baseline is central to forecast evaluation, and the choice of baseline itself can substantially change which models appear skilful [@stapperMindBaseline2025].
+Baselines are useful because they:
+
+- give an interpretable reference point for whether a model adds value beyond a naive extrapolation of recent trends;
+- are cheap to fit and robust, so they almost always produce a forecast to compare against;
+- help reveal when added model complexity is not justified by better performance.
+:::
+
 # Wrap up
 
 - Review what you've learned in this session with the [learning objectives](../reference/learning_objectives)

--- a/sessions/forecasting-concepts.qmd
+++ b/sessions/forecasting-concepts.qmd
@@ -419,8 +419,18 @@ Baselines are useful because they:
 - give an interpretable reference point for whether a model adds value beyond a naive extrapolation of recent trends;
 - are cheap to fit and robust, so they almost always produce a forecast to compare against;
 - help reveal when added model complexity is not justified by better performance.
+
+Which of these, if any, does the random walk renewal model we just fitted satisfy?
 :::
 
+::: {.callout-note collapse="true"}
+## Solution
+- Interpretable reference point: yes, it's just a naive extrapolation of the recent trend in $R_t$.
+- Cheap to fit and robust: not really. It's a full Bayesian latent-state model that takes appreciably longer to fit than a naive baseline, and we had to raise `adapt_delta` and supply initial values to sample it cleanly.
+- Revealing unnecessary complexity: yes, if competing models are compared against it fairly.
+
+Stapper & Funk [@stapperMindBaseline2025] set out five criteria for a good baseline (capturing key epidemiological dynamics, producing the required output format, using only commonly available data, simplicity, and calibrated uncertainty), and find that no single baseline meets all of them.
+:::
 # Wrap up
 
 - Review what you've learned in this session with the [learning objectives](../reference/learning_objectives)


### PR DESCRIPTION
Adds a short optional (collapsed) dropdown to the "Methods in practice" part of the forecasting concepts session, framing the random walk model as a *baseline* and explaining what baselines are and why they are useful.

Scope is intentionally small: a sentence or two plus a few bullet points and one citation.

- New bib entry: Stapper & Funk (2025), "Mind the Baseline" (medRxiv 10.1101/2025.08.01.25332807).
- New collapsed callout citing it.

Relates to #640 (broader idea of consistently positioning the random walk model as the course baseline).

> Generated by an agent; please review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)