### PR TITLE
Fix broken LaTeX in CRPS formula

### DIFF
--- a/sessions/forecast-evaluation.qmd
+++ b/sessions/forecast-evaluation.qmd
@@ -202,10 +202,10 @@ By balancing these two aspects, the CRPS provides a comprehensive measure of the
 ::: {.callout-tip .optional collapse="true"}
 #### Mathematical Definition
 
-The CRPS for a predictive distribution characterised by a cumulative distribution function $F$ and observed value $x$ is calculated as
+The CRPS for a predictive distribution characterised by a cumulative distribution function $F$ and observed value $y$ is calculated as
 
 $$
-CRPS(F, x) = \int_{-\infty}^{+\infty} \left( F(y) - \mathbb{1} ({\y \geq x})^2 \right).
+CRPS(F, y) = \int_{-\infty}^{+\infty} \left( F(x) - \mathbb{1}(x \geq y) \right)^2 \, dx
 $$
 
 For distributions with a finite first moment (a mean exists and it is finite), the CRPS can be expressed as:

--- a/sessions/forecast-evaluation.qmd
+++ b/sessions/forecast-evaluation.qmd
@@ -208,6 +208,8 @@ $$
 CRPS(F, y) = \int_{-\infty}^{+\infty} \left( F(x) - \mathbb{1}(x \geq y) \right)^2 \, dx
 $$
 
+where $\mathbb{1}(\cdot)$ is the indicator function, which evaluates to 1 if its argument is true and 0 if it is false.
+
 For distributions with a finite first moment (a mean exists and it is finite), the CRPS can be expressed as:
 
 $$


### PR DESCRIPTION
The CRPS integral in the forecast evaluation session rendered incorrectly (the observed value showed up red because of an invalid `\\y` macro).

The expression had three problems:
- `\\y` is not a valid LaTeX macro, so MathJax rendered it in red.
- the `^2` was inside the indicator argument rather than applied to the whole `(F - 1)` difference.
- the integration differential (`dx`) was missing.

It also used `x` as the observed value while the second formula used `y`. Fixed to:

  CRPS(F, y) = \\int_{-\\infty}^{+\\infty} ( F(x) - 1(x >= y) )^2 dx

so the observed value is `y` throughout and `x` is the integration dummy.

> Generated by an agent; please review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)