### PR TITLE
preview the wis in the evaluation session

### DIFF
--- a/sessions/forecast-evaluation.qmd
+++ b/sessions/forecast-evaluation.qmd
@@ -258,7 +258,7 @@ What does this tell you about the model?
 :::
 
 ::: {.callout-note .optional collapse="true"}
-# Probabilistic scoring without samples
+## Probabilistic scoring without samples
 Not all probabilistic forecasting models produce samples.
 The **weighted interval score (WIS)** [@bracherEvaluatingEpidemicForecasts2021] is a proper scoring rule for quantile forecasts that approximates the CRPS, by considering a weighted sum of multiple prediction intervals. 
 As the number of intervals increases, the WIS converges to the CRPS, combining sharpness and penalties for over- and under-prediction.

--- a/sessions/forecast-evaluation.qmd
+++ b/sessions/forecast-evaluation.qmd
@@ -261,7 +261,7 @@ What does this tell you about the model?
 ## Probabilistic scoring without samples
 Not all probabilistic forecasting models produce samples.
 The **weighted interval score (WIS)** [@bracherEvaluatingEpidemicForecasts2021] is a proper scoring rule for quantile forecasts that approximates the CRPS, by considering a weighted sum of multiple prediction intervals. 
-As the number of intervals increases, the WIS converges to the CRPS, combining sharpness and penalties for over- and under-prediction.
+This makes it the standard choice when forecasts are shared as quantiles or prediction intervals rather than samples, as is often done in collaborative forecasting hubs [@reichCollaborativeHubsMaking2022].
 :::
 
 ### PIT histograms

--- a/sessions/forecast-evaluation.qmd
+++ b/sessions/forecast-evaluation.qmd
@@ -257,6 +257,13 @@ What does this tell you about the model?
   - However, the CRPS increasing with forecast horizon is a sign that the model is struggling to capture the longer term dynamics of the epidemic.
 :::
 
+::: {.callout-note .optional collapse="true"}
+# Probabilistic scoring without samples
+Not all probabilistic forecasting models produce samples.
+The **weighted interval score (WIS)** [@bracherEvaluatingEpidemicForecasts2021] is a proper scoring rule for quantile forecasts that approximates the CRPS, by considering a weighted sum of multiple prediction intervals. 
+As the number of intervals increases, the WIS converges to the CRPS, combining sharpness and penalties for over- and under-prediction.
+:::
+
 ### PIT histograms
 
 As well as the CRPS we can also look at the calibration and bias of the model [@funkAssessingPerformanceRealtime2019]. Calibration is the agreement between the forecast probabilities and the observed frequencies. Bias is a measure of how likely the model is to over or under predict the observed values.


### PR DESCRIPTION
We currently introduce the WIS in the ensembles session. It might be nice to briefly preview this earlier, in the evaluation session when we intro the CRPS (so that people who skip ensembles still see the option). 

Suggesting to add as a brief optional note in the evaluation session. For starters I just copied the existing WIS description over (so it is repetitive, but since they are in different sessions maybe OK); edits welcome.

[opening the PR here as the 'canonical' repo?]